### PR TITLE
[MRG] Rename repo addresses

### DIFF
--- a/build_tools/travis/flake8_diff.sh
+++ b/build_tools/travis/flake8_diff.sh
@@ -23,7 +23,7 @@ set -e
 # pipefail is necessary to propagate exit codes
 set -o pipefail
 
-PROJECT=metric-learn/metric-learn
+PROJECT=scikit-learn-contrib/metric-learn
 PROJECT_URL=https://github.com/$PROJECT.git
 
 # Find the remote with the project name (upstream in most cases)

--- a/doc/weakly_supervised.rst
+++ b/doc/weakly_supervised.rst
@@ -694,7 +694,7 @@ like:
 
 (This is actually intentional, for more details
 about that, see
-`this comment <https://github.com/metric-learn/metric-learn/pull/168#pullrequestreview-203730742>`_
+`this comment <https://github.com/scikit-learn-contrib/metric-learn/pull/168#pullrequestreview-203730742>`_
 on github.)
 
 However, quadruplets learners do have a default scoring function, which will

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(name='metric-learn',
           'Nathalie Vauquier'
       ],
       author_email='ccarey@cs.umass.edu',
-      url='http://github.com/metric-learn/metric-learn',
+      url='http://github.com/scikit-learn-contrib/metric-learn',
       license='MIT',
       classifiers=[
           'Development Status :: 4 - Beta',

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -532,7 +532,7 @@ def test_toy_ex_lmnn(X, y, loss):
 
 def test_convergence_simple_example(capsys):
   # LMNN should converge on this simple example, which it did not with
-  # this issue: https://github.com/metric-learn/metric-learn/issues/88
+  # this issue: https://github.com/scikit-learn-contrib/metric-learn/issues/88
   X, y = make_classification(random_state=0)
   lmnn = LMNN(verbose=True)
   lmnn.fit(X, y)
@@ -542,7 +542,7 @@ def test_convergence_simple_example(capsys):
 
 def test_no_twice_same_objective(capsys):
   # test that the objective function never has twice the same value
-  # see https://github.com/metric-learn/metric-learn/issues/88
+  # see https://github.com/scikit-learn-contrib/metric-learn/issues/88
   X, y = make_classification(random_state=0)
   lmnn = LMNN(verbose=True)
   lmnn.fit(X, y)

--- a/test/test_components_metric_conversion.py
+++ b/test/test_components_metric_conversion.py
@@ -94,7 +94,7 @@ class TestTransformerMetricConversion(unittest.TestCase):
 
     # matrix with all its coefficients very low (to check that the algorithm
     # does not consider it as a diagonal matrix)(non regression test for
-    # https://github.com/metric-learn/metric-learn/issues/175)
+    # https://github.com/scikit-learn-contrib/metric-learn/issues/175)
     M = np.diag([1e-15, 2e-16, 3e-15, 4e-16, 5e-15, 6e-16, 7e-15])
     M = P.dot(M).dot(P.T)
     L = components_from_metric(M)

--- a/test/test_mahalanobis_mixin.py
+++ b/test/test_mahalanobis_mixin.py
@@ -573,8 +573,8 @@ def test_singular_covariance_init_or_prior(estimator, build_dataset):
     """Tests that when using the 'covariance' init or prior, it returns the
     appropriate error if the covariance matrix is singular, for algorithms
     that need a strictly PD prior or init (see
-    https://github.com/metric-learn/metric-learn/issues/202 and
-    https://github.com/metric-learn/metric-learn/pull/195#issuecomment
+    https://github.com/scikit-learn-contrib/metric-learn/issues/202 and
+    https://github.com/scikit-learn-contrib/metric-learn/pull/195#issuecomment
     -492332451)
     """
     matrices_to_set = []
@@ -618,8 +618,8 @@ def test_singular_array_init_or_prior(estimator, build_dataset, w0):
     """Tests that when using a custom array init (or prior), it returns the
     appropriate error if it is singular, for algorithms
     that need a strictly PD prior or init (see
-    https://github.com/metric-learn/metric-learn/issues/202 and
-    https://github.com/metric-learn/metric-learn/pull/195#issuecomment
+    https://github.com/scikit-learn-contrib/metric-learn/issues/202 and
+    https://github.com/scikit-learn-contrib/metric-learn/pull/195#issuecomment
     -492332451)
     """
     matrices_to_set = []


### PR DESCRIPTION
This renames all `metric-learn/metric-learn` into `scikit-learn-contrib/metric-learn`