### PR TITLE
Break chunks generation in RCA when not enough possible chunks, fixes issue #200

### DIFF
--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -79,10 +79,11 @@ class Constraints(object):
     chunks = -np.ones_like(self.known_label_idx, dtype=int)
     uniq, lookup = np.unique(self.known_labels, return_inverse=True)
     all_inds = [set(np.where(lookup == c)[0]) for c in xrange(len(uniq))]
-    max_chunks = np.sum([len(s) // chunk_size for s in all_inds])
+    max_chunks = int(np.sum([len(s) // chunk_size for s in all_inds]))
     if max_chunks < num_chunks:
-      raise ValueError(('Not enough examples in each class to form '
-                        '%d chunks of %d examples') % (num_chunks, chunk_size))
+      raise ValueError(('Not enough examples in each class to form %d chunks '
+                        'of %d examples - maximum number of chunks is %d'
+                        ) % (num_chunks, chunk_size, max_chunks))
     idx = 0
     while idx < num_chunks and all_inds:
       if len(all_inds) == 1:

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -80,9 +80,9 @@ class Constraints(object):
     uniq, lookup = np.unique(self.known_labels, return_inverse=True)
     all_inds = [set(np.where(lookup == c)[0]) for c in xrange(len(uniq))]
     max_chunks = np.sum([len(s) // chunk_size for s in all_inds])
-    if  max_chunks < num_chunks:
-      raise ValueError('Not enough examples in each class to form '
-                       +'%d chunks of %d examples' % (num_chunks, chunk_size))
+    if max_chunks < num_chunks:
+      raise ValueError(('Not enough examples in each class to form '
+                        '%d chunks of %d examples') % (num_chunks, chunk_size))
     idx = 0
     while idx < num_chunks and all_inds:
       if len(all_inds) == 1:

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -79,6 +79,10 @@ class Constraints(object):
     chunks = -np.ones_like(self.known_label_idx, dtype=int)
     uniq, lookup = np.unique(self.known_labels, return_inverse=True)
     all_inds = [set(np.where(lookup == c)[0]) for c in xrange(len(uniq))]
+    max_chunks = np.sum([len(s) // chunk_size for s in all_inds])
+    if  max_chunks < num_chunks:
+      raise ValueError('Not enough examples in each class to form '
+                       +'%d chunks of %d examples' % (num_chunks, chunk_size))
     idx = 0
     while idx < num_chunks and all_inds:
       if len(all_inds) == 1:
@@ -93,9 +97,6 @@ class Constraints(object):
       inds.difference_update(ii)
       chunks[ii] = idx
       idx += 1
-    if idx < num_chunks:
-      raise ValueError('Unable to make %d chunks of %d examples each' %
-                       (num_chunks, chunk_size))
     return chunks
 
 

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -81,9 +81,10 @@ class Constraints(object):
     all_inds = [set(np.where(lookup == c)[0]) for c in xrange(len(uniq))]
     max_chunks = int(np.sum([len(s) // chunk_size for s in all_inds]))
     if max_chunks < num_chunks:
-      raise ValueError(('Not enough examples in each class to form %d chunks '
-                        'of %d examples - maximum number of chunks is %d'
-                        ) % (num_chunks, chunk_size, max_chunks))
+      raise ValueError(('Not enough possible chunks of %d elements in each'
+                        ' class to form expected %d chunks - maximum number'
+                        ' of chunks is %d'
+                        ) % (chunk_size, num_chunks, max_chunks))
     idx = 0
     while idx < num_chunks and all_inds:
       if len(all_inds) == 1:

--- a/test/test_constraints.py
+++ b/test/test_constraints.py
@@ -25,38 +25,38 @@ def gen_labels_for_chunks(num_chunks, chunk_size,
   return shuffle(labels, random_state=SEED)
 
 
-class TestConstraints(unittest.TestCase):
-  def test_exact_num_points_for_chunks(self):
-    """Checks that the chunk generation works well with just enough points."""
-    for num_chunks, chunk_size in [(5, 10), (10, 50)]:
-      labels = gen_labels_for_chunks(num_chunks, chunk_size)
+@pytest.mark.parametrize("num_chunks, chunk_size", [(5, 10), (10, 50)])
+def test_exact_num_points_for_chunks(num_chunks, chunk_size):
+  """Checks that the chunk generation works well with just enough points."""
+  labels = gen_labels_for_chunks(num_chunks, chunk_size)
 
-      constraints = Constraints(labels)
-      chunks = constraints.chunks(num_chunks=num_chunks, chunk_size=chunk_size,
-                                  random_state=SEED)
+  constraints = Constraints(labels)
+  chunks = constraints.chunks(num_chunks=num_chunks, chunk_size=chunk_size,
+                              random_state=SEED)
 
-      chunk_no, size_each_chunk = np.unique(chunks, return_counts=True)
+  chunk_no, size_each_chunk = np.unique(chunks, return_counts=True)
 
-      self.assertTrue(np.all(size_each_chunk == chunk_size))
-      self.assertEqual(chunk_no.shape[0], num_chunks)
+  np.testing.assert_array_equal(size_each_chunk, chunk_size)
+  assert chunk_no.shape[0] == num_chunks
 
-  def test_chunk_case_one_miss_point(self):
-    """Checks that the chunk generation breaks when one point is missing."""
-    for num_chunks, chunk_size in [(5, 10), (10, 50)]:
-      labels = gen_labels_for_chunks(num_chunks, chunk_size)
 
-      assert len(labels) >= 1
-      constraints = Constraints(labels[1:])
-      with pytest.raises(ValueError) as e:
-        constraints.chunks(num_chunks=num_chunks, chunk_size=chunk_size,
-                           random_state=SEED)
+@pytest.mark.parametrize("num_chunks, chunk_size", [(5, 10), (10, 50)])
+def test_chunk_case_one_miss_point(num_chunks, chunk_size):
+  """Checks that the chunk generation breaks when one point is missing."""
+  labels = gen_labels_for_chunks(num_chunks, chunk_size)
 
-      expected_message = (('Not enough possible chunks of %d elements in each'
-                           ' class to form expected %d chunks - maximum number'
-                           ' of chunks is %d'
-                           ) % (chunk_size, num_chunks, num_chunks - 1))
+  assert len(labels) >= 1
+  constraints = Constraints(labels[1:])
+  with pytest.raises(ValueError) as e:
+    constraints.chunks(num_chunks=num_chunks, chunk_size=chunk_size,
+                       random_state=SEED)
 
-      self.assertEqual(str(e.value), expected_message)
+  expected_message = (('Not enough possible chunks of %d elements in each'
+                       ' class to form expected %d chunks - maximum number'
+                       ' of chunks is %d'
+                       ) % (chunk_size, num_chunks, num_chunks - 1))
+
+  assert str(e.value) == expected_message
 
 
 if __name__ == '__main__':

--- a/test/test_constraints.py
+++ b/test/test_constraints.py
@@ -1,0 +1,52 @@
+import pytest
+import numpy as np
+from sklearn.utils import shuffle
+from metric_learn.constraints import Constraints
+
+SEED = 42
+
+
+def gen_labels_for_chunks(num_chunks, chunk_size,
+                          n_classes=10, n_unknown_labels=5):
+  """Generates num_chunks*chunk_size labels that split in num_chunks chunks,
+  that are homogeneous in the label."""
+  classes = shuffle(np.arange(n_classes))
+  n_per_class = chunk_size * (num_chunks // n_classes)
+  n_maj_class = chunk_size * num_chunks - n_per_class * n_classes
+  most_labels = [[k] * n_per_class for k in classes[1:]]
+  labels = [classes[0] * n_maj_class] + most_labels + [-1] * n_unknown_labels
+  return labels
+
+
+@pytest.mark.parametrize('num_chunks, chunk_size', [(11, 5), (115, 12)])
+def test_chunk_case_exact_num_points(num_chunks, chunk_size,
+                                     n_classes=10, n_unknown_labels=5):
+  """Checks that the chunk generation works well with just enough points."""
+  labels = gen_labels_for_chunks(num_chunks, chunk_size,
+                                 n_classes=n_classes,
+                                 n_unknown_labels=n_unknown_labels)
+  constraints = Constraints(shuffle(labels, random_state=SEED))
+  chunks = constraints.chunks(num_chunks=num_chunks, chunk_size=chunk_size,
+                              random_state=SEED)
+  return chunks
+
+
+@pytest.mark.parametrize('num_chunks, chunk_size', [(5, 10), (10, 50)])
+def test_chunk_case_one_miss_point(num_chunks, chunk_size,
+                                   n_classes=10, n_unknown_labels=5):
+  """Checks that the chunk generation breaks when one point is missing."""
+  labels = gen_labels_for_chunks(num_chunks, chunk_size,
+                                 n_classes=n_classes,
+                                 n_unknown_labels=n_unknown_labels)
+  assert len(labels) >= 1
+  labels = shuffle(labels)[1:]
+  constraints = Constraints(shuffle(labels, random_state=SEED))
+  with pytest.raises(ValueError) as e:
+    constraints.chunks(num_chunks=num_chunks, chunk_size=chunk_size,
+                       random_state=SEED)
+
+  expected_message = (('Not enough examples in each class to form %d chunks '
+                       'of %d examples - maximum number of chunks is %d'
+                       ) % (num_chunks, chunk_size, num_chunks - 1))
+
+  assert e.value.message == expected_message

--- a/test/test_constraints.py
+++ b/test/test_constraints.py
@@ -10,12 +10,18 @@ def gen_labels_for_chunks(num_chunks, chunk_size,
                           n_classes=10, n_unknown_labels=5):
   """Generates num_chunks*chunk_size labels that split in num_chunks chunks,
   that are homogeneous in the label."""
-  classes = shuffle(np.arange(n_classes))
+  assert min(num_chunks, chunk_size) > 0
+  classes = shuffle(np.arange(n_classes), random_state=SEED)
   n_per_class = chunk_size * (num_chunks // n_classes)
   n_maj_class = chunk_size * num_chunks - n_per_class * n_classes
-  most_labels = [[k] * n_per_class for k in classes[1:]]
-  labels = [classes[0] * n_maj_class] + most_labels + [-1] * n_unknown_labels
-  return labels
+
+  first_labels = classes[0] * np.ones(n_maj_class, dtype=int)
+  remaining_labels = np.concatenate([k * np.ones(n_per_class, dtype=int)
+                                     for k in classes[1:]])
+  unknown_labels = -1 * np.ones(n_unknown_labels, dtype=int)
+
+  labels = np.concatenate([first_labels, remaining_labels, unknown_labels])
+  return shuffle(labels, random_state=SEED)
 
 
 @pytest.mark.parametrize('num_chunks, chunk_size', [(11, 5), (115, 12)])
@@ -25,7 +31,7 @@ def test_chunk_case_exact_num_points(num_chunks, chunk_size,
   labels = gen_labels_for_chunks(num_chunks, chunk_size,
                                  n_classes=n_classes,
                                  n_unknown_labels=n_unknown_labels)
-  constraints = Constraints(shuffle(labels, random_state=SEED))
+  constraints = Constraints(labels)
   chunks = constraints.chunks(num_chunks=num_chunks, chunk_size=chunk_size,
                               random_state=SEED)
   return chunks
@@ -39,8 +45,7 @@ def test_chunk_case_one_miss_point(num_chunks, chunk_size,
                                  n_classes=n_classes,
                                  n_unknown_labels=n_unknown_labels)
   assert len(labels) >= 1
-  labels = shuffle(labels)[1:]
-  constraints = Constraints(shuffle(labels, random_state=SEED))
+  constraints = Constraints(labels[1:])
   with pytest.raises(ValueError) as e:
     constraints.chunks(num_chunks=num_chunks, chunk_size=chunk_size,
                        random_state=SEED)
@@ -49,4 +54,4 @@ def test_chunk_case_one_miss_point(num_chunks, chunk_size,
                        'of %d examples - maximum number of chunks is %d'
                        ) % (num_chunks, chunk_size, num_chunks - 1))
 
-  assert e.value.message == expected_message
+  assert str(e.value) == expected_message

--- a/test/test_constraints.py
+++ b/test/test_constraints.py
@@ -13,7 +13,7 @@ def gen_labels_for_chunks(num_chunks, chunk_size,
   assert min(num_chunks, chunk_size) > 0
   classes = shuffle(np.arange(n_classes), random_state=SEED)
   n_per_class = chunk_size * (num_chunks // n_classes)
-  n_maj_class = chunk_size * num_chunks - n_per_class * n_classes
+  n_maj_class = n_per_class + chunk_size * num_chunks - n_per_class * n_classes
 
   first_labels = classes[0] * np.ones(n_maj_class, dtype=int)
   remaining_labels = np.concatenate([k * np.ones(n_per_class, dtype=int)


### PR DESCRIPTION
Fixes #200 
See comment https://github.com/scikit-learn-contrib/metric-learn/pull/198#issuecomment-490927459

I count for each set of instances of each label how many chunks it holds, and sum those.
If it is lower than the number of requested chunks, I raise an error.