### PR TITLE
Correct display of references problem in Sphinx 2.1.1, solves issue #262

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -65,3 +65,7 @@ sphinx_gallery_conf = {
 
 # generate autosummary even if no references
 autosummary_generate = True
+
+# Switch to old behavior with html4, for a good display of references,
+# as described in https://github.com/sphinx-doc/sphinx/issues/6705
+html4_writer = True


### PR DESCRIPTION
I found some info [there](https://github.com/sphinx-doc/sphinx/issues/6705) and added the workaround parameter to the `doc/conf.py` file to solve the problem. The new displaying of references requires modifying the CSS. The modification fixes issue #262 