### PR TITLE
Fix failing tests in last build

### DIFF
--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -240,14 +240,14 @@ class MahalanobisMixin(six.with_metaclass(ABCMeta, BaseMetricLearner,
     X_embedded : `numpy.ndarray`, shape=(n_samples, n_components)
       The embedded data points.
     """
-    check_is_fitted(self, ['preprocessor_', 'components_'])
+    check_is_fitted(self)
     X_checked = check_input(X, type_of_inputs='classic', estimator=self,
                             preprocessor=self.preprocessor_,
                             accept_sparse=True)
     return X_checked.dot(self.components_.T)
 
   def get_metric(self):
-    check_is_fitted(self, 'components_')
+    check_is_fitted(self)
     components_T = self.components_.T.copy()
 
     def metric_fun(u, v, squared=False):
@@ -300,7 +300,7 @@ class MahalanobisMixin(six.with_metaclass(ABCMeta, BaseMetricLearner,
     M : `numpy.ndarray`, shape=(n_features, n_features)
       The copy of the learned Mahalanobis matrix.
     """
-    check_is_fitted(self, 'components_')
+    check_is_fitted(self)
     return self.components_.T.dot(self.components_)
 
 
@@ -363,7 +363,7 @@ class _PairsClassifierMixin(BaseMetricLearner):
     y_predicted : `numpy.ndarray` of floats, shape=(n_constraints,)
       The predicted decision function value for each pair.
     """
-    check_is_fitted(self, 'preprocessor_')
+    check_is_fitted(self)
     pairs = check_input(pairs, type_of_inputs='tuples',
                         preprocessor=self.preprocessor_,
                         estimator=self, tuple_size=self._tuple_size)
@@ -606,7 +606,7 @@ class _QuadrupletsClassifierMixin(BaseMetricLearner):
     prediction : `numpy.ndarray` of floats, shape=(n_constraints,)
       Predictions of the ordering of pairs, for each quadruplet.
     """
-    check_is_fitted(self, 'preprocessor_')
+    check_is_fitted(self)
     quadruplets = check_input(quadruplets, type_of_inputs='tuples',
                               preprocessor=self.preprocessor_,
                               estimator=self, tuple_size=self._tuple_size)
@@ -635,7 +635,7 @@ class _QuadrupletsClassifierMixin(BaseMetricLearner):
     decision_function : `numpy.ndarray` of floats, shape=(n_constraints,)
       Metric differences.
     """
-    check_is_fitted(self, 'preprocessor_')
+    check_is_fitted(self)
     quadruplets = check_input(quadruplets, type_of_inputs='tuples',
                               preprocessor=self.preprocessor_,
                               estimator=self, tuple_size=self._tuple_size)

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -252,6 +252,7 @@ class MahalanobisMixin(six.with_metaclass(ABCMeta, BaseMetricLearner,
     return X_checked.dot(self.components_.T)
 
   def get_metric(self):
+    # TODO: remove when we stop supporting Python < 3.5
     if sys.version_info.major < 3 or sys.version_info.minor < 5:
       check_is_fitted(self, 'components_')
     else:
@@ -308,6 +309,7 @@ class MahalanobisMixin(six.with_metaclass(ABCMeta, BaseMetricLearner,
     M : `numpy.ndarray`, shape=(n_features, n_features)
       The copy of the learned Mahalanobis matrix.
     """
+    # TODO: remove when we stop supporting Python < 3.5
     if sys.version_info.major < 3 or sys.version_info.minor < 5:
       check_is_fitted(self, 'components_')
     else:
@@ -374,6 +376,7 @@ class _PairsClassifierMixin(BaseMetricLearner):
     y_predicted : `numpy.ndarray` of floats, shape=(n_constraints,)
       The predicted decision function value for each pair.
     """
+    # TODO: remove when we stop supporting Python < 3.5
     if sys.version_info.major < 3 or sys.version_info.minor < 5:
       check_is_fitted(self, 'preprocessor_')
     else:
@@ -620,6 +623,7 @@ class _QuadrupletsClassifierMixin(BaseMetricLearner):
     prediction : `numpy.ndarray` of floats, shape=(n_constraints,)
       Predictions of the ordering of pairs, for each quadruplet.
     """
+    # TODO: remove when we stop supporting Python < 3.5
     if sys.version_info.major < 3 or sys.version_info.minor < 5:
       check_is_fitted(self, 'preprocessor_')
     else:
@@ -652,6 +656,7 @@ class _QuadrupletsClassifierMixin(BaseMetricLearner):
     decision_function : `numpy.ndarray` of floats, shape=(n_constraints,)
       Metric differences.
     """
+    # TODO: remove when we stop supporting Python < 3.5
     if sys.version_info.major < 3 or sys.version_info.minor < 5:
       check_is_fitted(self, 'preprocessor_')
     else:

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -11,6 +11,7 @@ from abc import ABCMeta, abstractmethod
 import six
 from ._util import ArrayIndexer, check_input, validate_vector
 import warnings
+import sys
 
 
 class BaseMetricLearner(six.with_metaclass(ABCMeta, BaseEstimator)):
@@ -240,14 +241,21 @@ class MahalanobisMixin(six.with_metaclass(ABCMeta, BaseMetricLearner,
     X_embedded : `numpy.ndarray`, shape=(n_samples, n_components)
       The embedded data points.
     """
-    check_is_fitted(self)
+    # TODO: remove when we stop supporting Python < 3.5
+    if sys.version_info.major < 3 or sys.version_info.minor < 5:
+      check_is_fitted(self, ['preprocessor_', 'components_'])
+    else:
+      check_is_fitted(self)
     X_checked = check_input(X, type_of_inputs='classic', estimator=self,
                             preprocessor=self.preprocessor_,
                             accept_sparse=True)
     return X_checked.dot(self.components_.T)
 
   def get_metric(self):
-    check_is_fitted(self)
+    if sys.version_info.major < 3 or sys.version_info.minor < 5:
+      check_is_fitted(self, 'components_')
+    else:
+      check_is_fitted(self)
     components_T = self.components_.T.copy()
 
     def metric_fun(u, v, squared=False):
@@ -300,7 +308,10 @@ class MahalanobisMixin(six.with_metaclass(ABCMeta, BaseMetricLearner,
     M : `numpy.ndarray`, shape=(n_features, n_features)
       The copy of the learned Mahalanobis matrix.
     """
-    check_is_fitted(self)
+    if sys.version_info.major < 3 or sys.version_info.minor < 5:
+      check_is_fitted(self, 'components_')
+    else:
+      check_is_fitted(self)
     return self.components_.T.dot(self.components_)
 
 
@@ -363,7 +374,10 @@ class _PairsClassifierMixin(BaseMetricLearner):
     y_predicted : `numpy.ndarray` of floats, shape=(n_constraints,)
       The predicted decision function value for each pair.
     """
-    check_is_fitted(self)
+    if sys.version_info.major < 3 or sys.version_info.minor < 5:
+      check_is_fitted(self, 'preprocessor_')
+    else:
+      check_is_fitted(self)
     pairs = check_input(pairs, type_of_inputs='tuples',
                         preprocessor=self.preprocessor_,
                         estimator=self, tuple_size=self._tuple_size)
@@ -606,7 +620,10 @@ class _QuadrupletsClassifierMixin(BaseMetricLearner):
     prediction : `numpy.ndarray` of floats, shape=(n_constraints,)
       Predictions of the ordering of pairs, for each quadruplet.
     """
-    check_is_fitted(self)
+    if sys.version_info.major < 3 or sys.version_info.minor < 5:
+      check_is_fitted(self, 'preprocessor_')
+    else:
+      check_is_fitted(self)
     quadruplets = check_input(quadruplets, type_of_inputs='tuples',
                               preprocessor=self.preprocessor_,
                               estimator=self, tuple_size=self._tuple_size)
@@ -635,7 +652,10 @@ class _QuadrupletsClassifierMixin(BaseMetricLearner):
     decision_function : `numpy.ndarray` of floats, shape=(n_constraints,)
       Metric differences.
     """
-    check_is_fitted(self)
+    if sys.version_info.major < 3 or sys.version_info.minor < 5:
+      check_is_fitted(self, 'preprocessor_')
+    else:
+      check_is_fitted(self)
     quadruplets = check_input(quadruplets, type_of_inputs='tuples',
                               preprocessor=self.preprocessor_,
                               estimator=self, tuple_size=self._tuple_size)

--- a/test/test_pairs_classifiers.py
+++ b/test/test_pairs_classifiers.py
@@ -121,8 +121,7 @@ def test_threshold_different_scores_is_finite(estimator, build_dataset,
   estimator.fit(input_data, labels)
   with pytest.warns(None) as record:
     estimator.calibrate_threshold(input_data, labels, **kwargs)
-  for w in record:
-    print(record[w])
+  print(record)
   assert len(record) == 0
 
 

--- a/test/test_pairs_classifiers.py
+++ b/test/test_pairs_classifiers.py
@@ -121,6 +121,8 @@ def test_threshold_different_scores_is_finite(estimator, build_dataset,
   estimator.fit(input_data, labels)
   with pytest.warns(None) as record:
     estimator.calibrate_threshold(input_data, labels, **kwargs)
+  for w in record:
+    print(record[w])
   assert len(record) == 0
 
 

--- a/test/test_pairs_classifiers.py
+++ b/test/test_pairs_classifiers.py
@@ -121,7 +121,8 @@ def test_threshold_different_scores_is_finite(estimator, build_dataset,
   estimator.fit(input_data, labels)
   with pytest.warns(None) as record:
     estimator.calibrate_threshold(input_data, labels, **kwargs)
-  print(record)
+  for i in range(len(record)):
+    warning = record.list[i].message
   assert len(record) == 0
 
 

--- a/test/test_pairs_classifiers.py
+++ b/test/test_pairs_classifiers.py
@@ -121,8 +121,6 @@ def test_threshold_different_scores_is_finite(estimator, build_dataset,
   estimator.fit(input_data, labels)
   with pytest.warns(None) as record:
     estimator.calibrate_threshold(input_data, labels, **kwargs)
-  for i in range(len(record)):
-    print(record.list[i].message)
   assert len(record) == 0
 
 

--- a/test/test_pairs_classifiers.py
+++ b/test/test_pairs_classifiers.py
@@ -122,7 +122,7 @@ def test_threshold_different_scores_is_finite(estimator, build_dataset,
   with pytest.warns(None) as record:
     estimator.calibrate_threshold(input_data, labels, **kwargs)
   for i in range(len(record)):
-    warning = record.list[i].message
+    print(record.list[i].message)
   assert len(record) == 0
 
 


### PR DESCRIPTION
The problem is due to a deprecation warning for `check_is_fitted` in the new version of sklearn (see below)

This PR fixes this by not using the attributes argument when calling `check_is_fitted`.