### PR TITLE
Revert changes in #270 due to revert decision in sklearn

### DIFF
--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -11,7 +11,6 @@ from abc import ABCMeta, abstractmethod
 import six
 from ._util import ArrayIndexer, check_input, validate_vector
 import warnings
-import sys
 
 
 class BaseMetricLearner(six.with_metaclass(ABCMeta, BaseEstimator)):
@@ -241,22 +240,14 @@ class MahalanobisMixin(six.with_metaclass(ABCMeta, BaseMetricLearner,
     X_embedded : `numpy.ndarray`, shape=(n_samples, n_components)
       The embedded data points.
     """
-    # TODO: remove when we stop supporting Python < 3.5
-    if sys.version_info.major < 3 or sys.version_info.minor < 5:
-      check_is_fitted(self, ['preprocessor_', 'components_'])
-    else:
-      check_is_fitted(self)
+    check_is_fitted(self, ['preprocessor_', 'components_'])
     X_checked = check_input(X, type_of_inputs='classic', estimator=self,
                             preprocessor=self.preprocessor_,
                             accept_sparse=True)
     return X_checked.dot(self.components_.T)
 
   def get_metric(self):
-    # TODO: remove when we stop supporting Python < 3.5
-    if sys.version_info.major < 3 or sys.version_info.minor < 5:
-      check_is_fitted(self, 'components_')
-    else:
-      check_is_fitted(self)
+    check_is_fitted(self, 'components_')
     components_T = self.components_.T.copy()
 
     def metric_fun(u, v, squared=False):
@@ -309,11 +300,7 @@ class MahalanobisMixin(six.with_metaclass(ABCMeta, BaseMetricLearner,
     M : `numpy.ndarray`, shape=(n_features, n_features)
       The copy of the learned Mahalanobis matrix.
     """
-    # TODO: remove when we stop supporting Python < 3.5
-    if sys.version_info.major < 3 or sys.version_info.minor < 5:
-      check_is_fitted(self, 'components_')
-    else:
-      check_is_fitted(self)
+    check_is_fitted(self, 'components_')
     return self.components_.T.dot(self.components_)
 
 
@@ -376,11 +363,7 @@ class _PairsClassifierMixin(BaseMetricLearner):
     y_predicted : `numpy.ndarray` of floats, shape=(n_constraints,)
       The predicted decision function value for each pair.
     """
-    # TODO: remove when we stop supporting Python < 3.5
-    if sys.version_info.major < 3 or sys.version_info.minor < 5:
-      check_is_fitted(self, 'preprocessor_')
-    else:
-      check_is_fitted(self)
+    check_is_fitted(self, 'preprocessor_')
     pairs = check_input(pairs, type_of_inputs='tuples',
                         preprocessor=self.preprocessor_,
                         estimator=self, tuple_size=self._tuple_size)
@@ -623,11 +606,7 @@ class _QuadrupletsClassifierMixin(BaseMetricLearner):
     prediction : `numpy.ndarray` of floats, shape=(n_constraints,)
       Predictions of the ordering of pairs, for each quadruplet.
     """
-    # TODO: remove when we stop supporting Python < 3.5
-    if sys.version_info.major < 3 or sys.version_info.minor < 5:
-      check_is_fitted(self, 'preprocessor_')
-    else:
-      check_is_fitted(self)
+    check_is_fitted(self, 'preprocessor_')
     quadruplets = check_input(quadruplets, type_of_inputs='tuples',
                               preprocessor=self.preprocessor_,
                               estimator=self, tuple_size=self._tuple_size)
@@ -656,11 +635,7 @@ class _QuadrupletsClassifierMixin(BaseMetricLearner):
     decision_function : `numpy.ndarray` of floats, shape=(n_constraints,)
       Metric differences.
     """
-    # TODO: remove when we stop supporting Python < 3.5
-    if sys.version_info.major < 3 or sys.version_info.minor < 5:
-      check_is_fitted(self, 'preprocessor_')
-    else:
-      check_is_fitted(self)
+    check_is_fitted(self, 'preprocessor_')
     quadruplets = check_input(quadruplets, type_of_inputs='tuples',
                               preprocessor=self.preprocessor_,
                               estimator=self, tuple_size=self._tuple_size)


### PR DESCRIPTION
This PR reverts the changes introduced in #270. These changes were introduced to be compatible with changes in sklearn's `check_is_fitted` introduced in https://github.com/scikit-learn/scikit-learn/pull/14545

However the last release of sklearn has reverted these changes as they were creating some problems, see https://github.com/scikit-learn/scikit-learn/pull/15947

This avoids the hassle of checking Python version, and the need to have sklearn >= 0.22.0 for Python >= 3.5