### PR TITLE
Fix covariance initialization when matrix is not invertible

### DIFF
--- a/metric_learn/_util.py
+++ b/metric_learn/_util.py
@@ -719,9 +719,9 @@ def _initialize_metric_mahalanobis(input, init='identity', random_state=None,
                         "require the `{}` to be strictly positive definite."
                         .format(*((matrix_name,) * 2)))
     elif not cov_is_definite:
-      warnings.warn('The initialization matrix is not invertible: '
+      warnings.warn('The covariance matrix is not invertible: '
                     'using the pseudo-inverse instead.'
-                    'To make the inverse covariance matrix invertible'
+                    'To make the covariance matrix invertible'
                     ' you can remove any linearly dependent features and/or '
                     'reduce the dimensionality of your input, '
                     'for instance using `sklearn.decomposition.PCA` as a '

--- a/metric_learn/_util.py
+++ b/metric_learn/_util.py
@@ -707,15 +707,19 @@ def _initialize_metric_mahalanobis(input, init='identity', random_state=None,
       X = input
     # atleast2d is necessary to deal with scalar covariance matrices
     M_inv = np.atleast_2d(np.cov(X, rowvar=False))
-    s, u = scipy.linalg.eigh(M_inv)
-    cov_is_definite = _check_sdp_from_eigen(s)
-    if strict_pd and not cov_is_definite:
-      raise LinAlgError("Unable to get a true inverse of the covariance "
-                        "matrix since it is not definite. Try another "
-                        "`{}`, or an algorithm that does not "
-                        "require the `{}` to be strictly positive definite."
-                        .format(*((matrix_name,) * 2)))
-    M = np.dot(u / s, u.T)
+    if strict_pd:
+      s, u = scipy.linalg.eigh(M_inv)
+      cov_is_definite = _check_sdp_from_eigen(s)
+      if not cov_is_definite:
+        raise LinAlgError("Unable to get a true inverse of the covariance "
+                          "matrix since it is not definite. Try another "
+                          "`{}`, or an algorithm that does not "
+                          "require the `{}` to be strictly positive definite."
+                          .format(*((matrix_name,) * 2)))
+      else:
+        M = np.dot(u / s, u.T)
+    else:
+      M = pinvh(M_inv)
     if return_inverse:
       return M, M_inv
     else:

--- a/metric_learn/_util.py
+++ b/metric_learn/_util.py
@@ -1,5 +1,4 @@
 import numpy as np
-import scipy
 import six
 from numpy.linalg import LinAlgError
 from sklearn.datasets import make_spd_matrix
@@ -8,7 +7,7 @@ from sklearn.utils import check_array
 from sklearn.utils.validation import check_X_y, check_random_state
 from .exceptions import PreprocessorError, NonPSDError
 from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
-from scipy.linalg import pinvh
+from scipy.linalg import pinvh, eigh
 import sys
 import time
 
@@ -679,7 +678,7 @@ def _initialize_metric_mahalanobis(input, init='identity', random_state=None,
   random_state = check_random_state(random_state)
   M = init
   if isinstance(init, np.ndarray):
-    s, u = scipy.linalg.eigh(init)
+    s, u = eigh(init)
     init_is_definite = _check_sdp_from_eigen(s)
     if strict_pd and not init_is_definite:
       raise LinAlgError("You should provide a strictly positive definite "
@@ -708,7 +707,7 @@ def _initialize_metric_mahalanobis(input, init='identity', random_state=None,
     # atleast2d is necessary to deal with scalar covariance matrices
     M_inv = np.atleast_2d(np.cov(X, rowvar=False))
     if strict_pd:
-      s, u = scipy.linalg.eigh(M_inv)
+      s, u = eigh(M_inv)
       cov_is_definite = _check_sdp_from_eigen(s)
       if not cov_is_definite:
         raise LinAlgError("Unable to get a true inverse of the covariance "

--- a/metric_learn/_util.py
+++ b/metric_learn/_util.py
@@ -688,8 +688,8 @@ def _initialize_metric_mahalanobis(input, init='identity', random_state=None,
                         "require the {} to be strictly positive definite."
                         .format(*((matrix_name,) * 3)))
     elif return_inverse and not init_is_definite:
-      warnings.warn('The initialization matrix is not invertible, '
-                    'but this isn"t an issue as the pseudo-inverse is used.')
+      warnings.warn('The initialization matrix is not invertible: '
+                    'using the pseudo-inverse instead.')
     if return_inverse:
       M_inv = _pseudo_inverse_from_eig(w, V)
       return M, M_inv
@@ -719,9 +719,10 @@ def _initialize_metric_mahalanobis(input, init='identity', random_state=None,
                         "require the `{}` to be strictly positive definite."
                         .format(*((matrix_name,) * 2)))
     elif not cov_is_definite:
-      warnings.warn('The inverse covariance matrix is not invertible, '
-                    'but this isn"t an issue as the pseudo-inverse is used. '
-                    'You can remove any linearly dependent features and/or '
+      warnings.warn('The initialization matrix is not invertible: '
+                    'using the pseudo-inverse instead.'
+                    'To make the inverse covariance matrix invertible'
+                    ' you can remove any linearly dependent features and/or '
                     'reduce the dimensionality of your input, '
                     'for instance using `sklearn.decomposition.PCA` as a '
                     'preprocessing step.')

--- a/metric_learn/_util.py
+++ b/metric_learn/_util.py
@@ -774,7 +774,7 @@ def _pseudo_inverse_from_eig(w, V, tol=None):
 
   Returns
   -------
-  output : (…, M, N) array_like
+  output : (..., M, N) array_like
     The pseudo-inverse given by the EVD.
   """
   if tol is None:

--- a/metric_learn/_util.py
+++ b/metric_learn/_util.py
@@ -677,8 +677,8 @@ def _initialize_metric_mahalanobis(input, init='identity', random_state=None,
 
   random_state = check_random_state(random_state)
   M = init
-  if isinstance(init, np.ndarray):
-    s, u = eigh(init)
+  if isinstance(M, np.ndarray):
+    s, u = eigh(M)
     init_is_definite = _check_sdp_from_eigen(s)
     if strict_pd and not init_is_definite:
       raise LinAlgError("You should provide a strictly positive definite "
@@ -687,7 +687,7 @@ def _initialize_metric_mahalanobis(input, init='identity', random_state=None,
                         "require the {} to be strictly positive definite."
                         .format(*((matrix_name,) * 3)))
     if return_inverse:
-      M_inv = np.dot(u / s, u.T)
+      M_inv = pinvh(M)
       return M, M_inv
     else:
       return M

--- a/test/test_mahalanobis_mixin.py
+++ b/test/test_mahalanobis_mixin.py
@@ -628,9 +628,9 @@ def test_singular_covariance_init_of_non_strict_pd(estimator, build_dataset):
                                                                         [3]])],
                                 axis=-1)
     model.set_params(init='covariance')
-    msg = ('The initialization matrix is not invertible: '
+    msg = ('The covariance matrix is not invertible: '
            'using the pseudo-inverse instead.'
-           'To make the inverse covariance matrix invertible'
+           'To make the covariance matrix invertible'
            ' you can remove any linearly dependent features and/or '
            'reduce the dimensionality of your input, '
            'for instance using `sklearn.decomposition.PCA` as a '

--- a/test/test_mahalanobis_mixin.py
+++ b/test/test_mahalanobis_mixin.py
@@ -638,7 +638,10 @@ def test_singular_covariance_init_of_non_strict_pd(estimator, build_dataset):
     with pytest.warns(UserWarning) as raised_warning:
       model.fit(input_data, labels)
     assert np.any([str(warning.message) == msg for warning in raised_warning])
-    M = model.get_mahalanobis_matrix()
+    M, _ = _initialize_metric_mahalanobis(X, init='covariance',
+                                          random_state=RNG,
+                                          return_inverse=True,
+                                          strict_pd=False)
     assert np.isfinite(M).all()
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1151,8 +1151,9 @@ def test__auto_select_init(has_classes, n_features, n_samples, n_components,
 
 @pytest.mark.parametrize('w0', [1e-20, 0., -1e-20])
 def test_pseudo_inverse_from_eig_and_pinvh_singular(w0):
-  """Checks that _pseudo_inverse_from_eig return the same result as
+  """Checks that _pseudo_inverse_from_eig returns the same result as
   scipy.linalg.pinvh for a singular matrix"""
+  np.random.seed(seed=SEED)
   A = np.random.rand(100, 100)
   A = A + A.T
   w, V = eigh(A)
@@ -1163,8 +1164,9 @@ def test_pseudo_inverse_from_eig_and_pinvh_singular(w0):
 
 
 def test_pseudo_inverse_from_eig_and_pinvh_nonsingular():
-  """Checks that _pseudo_inverse_from_eig return the same result as
+  """Checks that _pseudo_inverse_from_eig returns the same result as
   scipy.linalg.pinvh for a non singular matrix"""
+  np.random.seed(seed=SEED)
   A = np.random.rand(100, 100)
   A = A + A.T
   w, V = eigh(A, check_finite=False)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1158,7 +1158,8 @@ def test_pseudo_inverse_from_eig_and_pinvh_singular(w0):
   w, V = eigh(A)
   w[0] = w0
   A = V.dot(np.diag(w)).dot(V.T)
-  np.testing.assert_allclose(_pseudo_inverse_from_eig(w, V), pinvh(A))
+  np.testing.assert_allclose(_pseudo_inverse_from_eig(w, V), pinvh(A),
+                             rtol=1e-06)
 
 
 def test_pseudo_inverse_from_eig_and_pinvh_nonsingular():
@@ -1167,5 +1168,4 @@ def test_pseudo_inverse_from_eig_and_pinvh_nonsingular():
   A = np.random.rand(100, 100)
   A = A + A.T
   w, V = eigh(A, check_finite=False)
-  np.testing.assert_allclose(_pseudo_inverse_from_eig(w, V), pinvh(A),
-                             rtol=1e-09)
+  np.testing.assert_allclose(_pseudo_inverse_from_eig(w, V), pinvh(A))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1167,4 +1167,5 @@ def test_pseudo_inverse_from_eig_and_pinvh_nonsingular():
   A = np.random.rand(100, 100)
   A = A + A.T
   w, V = eigh(A, check_finite=False)
-  np.testing.assert_allclose(_pseudo_inverse_from_eig(w, V), pinvh(A))
+  np.testing.assert_allclose(_pseudo_inverse_from_eig(w, V), pinvh(A),
+                             rtol=1e-09)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1149,9 +1149,22 @@ def test__auto_select_init(has_classes, n_features, n_samples, n_components,
                             n_samples, n_components, n_classes) == result)
 
 
-def test_pseudo_inverse_from_eig_and_pinvh():
+@pytest.mark.parametrize('w0', [1e-20, 0., -1e-20])
+def test_pseudo_inverse_from_eig_and_pinvh_singular(w0):
   """Checks that _pseudo_inverse_from_eig return the same result as
-  scipy.linalg.pinvh"""
+  scipy.linalg.pinvh for a singular matrix"""
   A = np.random.rand(100, 100)
+  A = A + A.T
+  w, V = eigh(A)
+  w[0] = w0
+  A = V.dot(np.diag(w)).dot(V.T)
+  np.testing.assert_allclose(_pseudo_inverse_from_eig(w, V), pinvh(A))
+
+
+def test_pseudo_inverse_from_eig_and_pinvh_nonsingular():
+  """Checks that _pseudo_inverse_from_eig return the same result as
+  scipy.linalg.pinvh for a non singular matrix"""
+  A = np.random.rand(100, 100)
+  A = A + A.T
   w, V = eigh(A, check_finite=False)
-  assert np.array_equal(_pseudo_inverse_from_eig(w, V), pinvh(A))
+  np.testing.assert_allclose(_pseudo_inverse_from_eig(w, V), pinvh(A))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1159,7 +1159,7 @@ def test_pseudo_inverse_from_eig_and_pinvh_singular(w0):
   w[0] = w0
   A = V.dot(np.diag(w)).dot(V.T)
   np.testing.assert_allclose(_pseudo_inverse_from_eig(w, V), pinvh(A),
-                             rtol=1e-06)
+                             rtol=1e-05)
 
 
 def test_pseudo_inverse_from_eig_and_pinvh_nonsingular():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1153,8 +1153,8 @@ def test__auto_select_init(has_classes, n_features, n_samples, n_components,
 def test_pseudo_inverse_from_eig_and_pinvh_singular(w0):
   """Checks that _pseudo_inverse_from_eig returns the same result as
   scipy.linalg.pinvh for a singular matrix"""
-  np.random.seed(seed=SEED)
-  A = np.random.rand(100, 100)
+  rng = np.random.RandomState(SEED)
+  A = rng.rand(100, 100)
   A = A + A.T
   w, V = eigh(A)
   w[0] = w0
@@ -1166,8 +1166,8 @@ def test_pseudo_inverse_from_eig_and_pinvh_singular(w0):
 def test_pseudo_inverse_from_eig_and_pinvh_nonsingular():
   """Checks that _pseudo_inverse_from_eig returns the same result as
   scipy.linalg.pinvh for a non singular matrix"""
-  np.random.seed(seed=SEED)
-  A = np.random.rand(100, 100)
+  rng = np.random.RandomState(SEED)
+  A = rng.rand(100, 100)
   A = A + A.T
   w, V = eigh(A, check_finite=False)
   np.testing.assert_allclose(_pseudo_inverse_from_eig(w, V), pinvh(A))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+from scipy.linalg import eigh, pinvh
 from collections import namedtuple
 import numpy as np
 from numpy.testing import assert_array_equal, assert_equal
@@ -11,7 +12,7 @@ from metric_learn._util import (check_input, make_context, preprocess_tuples,
                                 check_collapsed_pairs, validate_vector,
                                 _check_sdp_from_eigen, _check_n_components,
                                 check_y_valid_values_for_pairs,
-                                _auto_select_init)
+                                _auto_select_init, _pseudo_inverse_from_eig)
 from metric_learn import (ITML, LSML, MMC, RCA, SDML, Covariance, LFDA,
                           LMNN, MLKR, NCA, ITML_Supervised, LSML_Supervised,
                           MMC_Supervised, RCA_Supervised, SDML_Supervised,
@@ -1146,3 +1147,11 @@ def test__auto_select_init(has_classes, n_features, n_samples, n_components,
   """Checks that the auto selection of the init works as expected"""
   assert (_auto_select_init(has_classes, n_features,
                             n_samples, n_components, n_classes) == result)
+
+
+def test_pseudo_inverse_from_eig_and_pinvh():
+  """Checks that _pseudo_inverse_from_eig return the same result as
+  scipy.linalg.pinvh"""
+  A = np.random.rand(100, 100)
+  w, V = eigh(A, check_finite=False)
+  assert np.array_equal(_pseudo_inverse_from_eig(w, V), pinvh(A))


### PR DESCRIPTION
This PR fixes #276, an issue that arises in the context of covariance initialization on an algorithm that doesn't require a PD matrix. It can happen that the calculated matrix is singular and in consequence isn't invertible, leading to non-explicative warnings. This is fixed by the use of a pseudo-inverse when a PD matrix is not required.