### PR TITLE
SCML : Sparse Compositional Metric Learning

### DIFF
--- a/doc/metric_learn.rst
+++ b/doc/metric_learn.rst
@@ -33,6 +33,7 @@ Supervised Learning Algorithms
    metric_learn.MMC_Supervised
    metric_learn.SDML_Supervised
    metric_learn.RCA_Supervised
+   metric_learn.SCML_Supervised
 
 Weakly Supervised Learning Algorithms
 -------------------------------------
@@ -45,6 +46,7 @@ Weakly Supervised Learning Algorithms
    metric_learn.LSML
    metric_learn.MMC
    metric_learn.SDML
+   metric_learn.SCML
 
 Unsupervised Learning Algorithms
 --------------------------------

--- a/doc/weakly_supervised.rst
+++ b/doc/weakly_supervised.rst
@@ -700,6 +700,60 @@ of triplets that have the right predicted ordering.
 Algorithms
 ----------
 
+.. _scml:
+
+:py:class:`SCML <metric_learn.SCML>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Sparse Compositional Metric Learning
+(:py:class:`SCML <metric_learn.SCML>`)
+
+`SCML` learns an squared mahalanobis distance from triplet constraints by 
+optimizing sparse positive weights assigned to a set of :math:`K` locally discriminative 
+rank-one PSD bases. This can be formulated as an optimization problem with only :math:`K`
+parameters, that can be solved with an efficient stochastic composite scheme.
+
+The Mahalanobis Matrix :math:`M` is built from a basis set :math:`B = \{b_i\}_{i=\{1,...,K\}}`
+weighted by a :math:`K` dimensional vector :math:`w = \{w_i\}_{i=\{1,...,K\}}` as:
+
+.. math::
+
+    M = \sum_{i=1}^K w_i b_i b_i^T = B \cdot diag(w) \cdot B^T \quad w_i \geq 0
+
+Learning :math:`M` in this form makes it PSD by design, as it is a nonnegative sum of PSD matrices.
+The optimization problem of :math:`w` over the triplets constraints :math:`C` is formulated as a
+classic margin-based hinge loss function over the relative constrains, a regularization :math:`\ell_1`
+is added to yield an sparse representation. The formulation is the following:
+
+.. math::
+
+    \min_{w} \sum_{(x_a,x_b,x_c)\in C} [1 + d_w(x_a,x_b)-d_w(x_a,x_c)]_+ + \beta||w||_1
+
+Where :math:`[\cdot]_+` is the hinge loss. 
+ 
+.. topic:: Example Code:
+
+::
+
+    from metric_learn import SCML
+
+    triplets = [[[1.2, 7.5], [1.3, 1.5], [6.2, 9.7]],
+                [[1.3, 4.5], [3.2, 4.6], [5.4, 5.4]],
+                [[3.2, 7.5], [3.3, 1.5], [8.2, 9.7]],
+                [[3.3, 4.5], [5.2, 4.6], [7.4, 5.4]]]
+
+    scml = SCML()
+    scml.fit(triplets)
+
+.. topic:: References:
+
+  .. [1] Y. Shi, A. Bellet and F. Sha. `Sparse Compositional Metric Learning.
+         <http://researchers.lille.inria.fr/abellet/papers/aaai14.pdf>`_. \
+         (AAAI), 2014.
+
+  .. [2] Adapted from original \
+         `Matlab implementation.<https://github.com/bellet/SCML>`_.
+
 
 .. _learning_on_quadruplets:
 

--- a/doc/weakly_supervised.rst
+++ b/doc/weakly_supervised.rst
@@ -708,28 +708,31 @@ Algorithms
 Sparse Compositional Metric Learning
 (:py:class:`SCML <metric_learn.SCML>`)
 
-`SCML` learns an squared mahalanobis distance from triplet constraints by 
-optimizing sparse positive weights assigned to a set of :math:`K` locally discriminative 
-rank-one PSD bases. This can be formulated as an optimization problem with only :math:`K`
-parameters, that can be solved with an efficient stochastic composite scheme.
+`SCML` learns an squared Mahalanobis distance from triplet constraints by
+optimizing sparse positive weights assigned to a set of :math:`K` rank-one
+PSD bases. This can be formulated as an optimization problem with only
+:math:`K` parameters, that can be solved with an efficient stochastic
+composite scheme.
 
-The Mahalanobis Matrix :math:`M` is built from a basis set :math:`B = \{b_i\}_{i=\{1,...,K\}}`
+The Mahalanobis matrix :math:`M` is built from a basis set :math:`B = \{b_i\}_{i=\{1,...,K\}}`
 weighted by a :math:`K` dimensional vector :math:`w = \{w_i\}_{i=\{1,...,K\}}` as:
 
 .. math::
 
     M = \sum_{i=1}^K w_i b_i b_i^T = B \cdot diag(w) \cdot B^T \quad w_i \geq 0
 
-Learning :math:`M` in this form makes it PSD by design, as it is a nonnegative sum of PSD matrices.
-The optimization problem of :math:`w` over the triplets constraints :math:`C` is formulated as a
-classic margin-based hinge loss function over the relative constrains, a regularization :math:`\ell_1`
-is added to yield an sparse representation. The formulation is the following:
+Learning :math:`M` in this form makes it PSD by design, as it is a
+nonnegative sum of PSD matrices. The basis set :math:`B` is fixed on advance
+and it is possible to construct it from the data. The optimization problem
+over :math:`w` is formulated as a classic margin-based hinge loss function
+involving the set :math:`C` of triplets. A regularization :math:`\ell_1`
+is added to yield a sparse combination. The formulation is the following:
 
 .. math::
 
-    \min_{w} \sum_{(x_a,x_b,x_c)\in C} [1 + d_w(x_a,x_b)-d_w(x_a,x_c)]_+ + \beta||w||_1
+    \min_{w\geq 0} \sum_{(x_i,x_j,x_k)\in C} [1 + d_w(x_i,x_j)-d_w(x_i,x_k)]_+ + \beta||w||_1
 
-Where :math:`[\cdot]_+` is the hinge loss. 
+where :math:`[\cdot]_+` is the hinge loss. 
  
 .. topic:: Example Code:
 
@@ -883,13 +886,13 @@ extension leads to more stable estimation when the dimension is high and
 only a small amount of constraints is given.
 
 The loss function of each constraint 
-:math:`d(\mathbf{x}_a, \mathbf{x}_b) < d(\mathbf{x}_c, \mathbf{x}_d)` is 
+:math:`d(\mathbf{x}_i, \mathbf{x}_j) < d(\mathbf{x}_k, \mathbf{x}_l)` is 
 denoted as:
 
 .. math::
 
-    H(d_\mathbf{M}(\mathbf{x}_a, \mathbf{x}_b) 
-    - d_\mathbf{M}(\mathbf{x}_c, \mathbf{x}_d))
+    H(d_\mathbf{M}(\mathbf{x}_i, \mathbf{x}_j) 
+    - d_\mathbf{M}(\mathbf{x}_k, \mathbf{x}_l))
 
 where :math:`H(\cdot)` is the squared Hinge loss function defined as:
 
@@ -899,8 +902,8 @@ where :math:`H(\cdot)` is the squared Hinge loss function defined as:
     \,\,x^2 \qquad x>0\end{aligned}\right.\\
 
 The summed loss function :math:`L(C)` is the simple sum over all constraints 
-:math:`C = \{(\mathbf{x}_a , \mathbf{x}_b , \mathbf{x}_c , \mathbf{x}_d) 
-: d(\mathbf{x}_a , \mathbf{x}_b) < d(\mathbf{x}_c , \mathbf{x}_d)\}`. The 
+:math:`C = \{(\mathbf{x}_i , \mathbf{x}_j , \mathbf{x}_k , \mathbf{x}_l) 
+: d(\mathbf{x}_i , \mathbf{x}_j) < d(\mathbf{x}_k , \mathbf{x}_l)\}`. The 
 original paper suggested here should be a weighted sum since the confidence 
 or probability of each constraint might differ. However, for the sake of 
 simplicity and assumption of no extra knowledge provided, we just deploy 
@@ -912,9 +915,9 @@ knowledge:
 
 .. math::
 
-    \min_\mathbf{M}(D_{ld}(\mathbf{M, M_0}) + \sum_{(\mathbf{x}_a, 
-    \mathbf{x}_b, \mathbf{x}_c, \mathbf{x}_d)\in C}H(d_\mathbf{M}(
-    \mathbf{x}_a, \mathbf{x}_b) - d_\mathbf{M}(\mathbf{x}_c, \mathbf{x}_c))\\
+    \min_\mathbf{M}(D_{ld}(\mathbf{M, M_0}) + \sum_{(\mathbf{x}_i, 
+    \mathbf{x}_j, \mathbf{x}_k, \mathbf{x}_l)\in C}H(d_\mathbf{M}(
+    \mathbf{x}_i, \mathbf{x}_j) - d_\mathbf{M}(\mathbf{x}_k, \mathbf{x}_l))\\
 
 where :math:`\mathbf{M}_0` is the prior metric matrix, set as identity 
 by default, :math:`D_{ld}(\mathbf{\cdot, \cdot})` is the LogDet divergence:

--- a/doc/weakly_supervised.rst
+++ b/doc/weakly_supervised.rst
@@ -708,7 +708,7 @@ Algorithms
 Sparse Compositional Metric Learning
 (:py:class:`SCML <metric_learn.SCML>`)
 
-`SCML` learns an squared Mahalanobis distance from triplet constraints by
+`SCML` learns a squared Mahalanobis distance from triplet constraints by
 optimizing sparse positive weights assigned to a set of :math:`K` rank-one
 PSD bases. This can be formulated as an optimization problem with only
 :math:`K` parameters, that can be solved with an efficient stochastic
@@ -722,7 +722,7 @@ weighted by a :math:`K` dimensional vector :math:`w = \{w_i\}_{i=\{1,...,K\}}` a
     M = \sum_{i=1}^K w_i b_i b_i^T = B \cdot diag(w) \cdot B^T \quad w_i \geq 0
 
 Learning :math:`M` in this form makes it PSD by design, as it is a
-nonnegative sum of PSD matrices. The basis set :math:`B` is fixed on advance
+nonnegative sum of PSD matrices. The basis set :math:`B` is fixed in advance
 and it is possible to construct it from the data. The optimization problem
 over :math:`w` is formulated as a classic margin-based hinge loss function
 involving the set :math:`C` of triplets. A regularization :math:`\ell_1`

--- a/metric_learn/__init__.py
+++ b/metric_learn/__init__.py
@@ -11,12 +11,12 @@ from .lfda import LFDA
 from .rca import RCA, RCA_Supervised
 from .mlkr import MLKR
 from .mmc import MMC, MMC_Supervised
-from .scml import SCML_global, SCML_global_Supervised
+from .scml import SCML, SCML_Supervised
 
 from ._version import __version__
 
 __all__ = ['Constraints', 'Covariance', 'ITML', 'ITML_Supervised',
            'LMNN', 'LSML', 'LSML_Supervised', 'SDML',
            'SDML_Supervised', 'NCA', 'LFDA', 'RCA', 'RCA_Supervised',
-           'MLKR', 'MMC', 'MMC_Supervised', 'SCML_global',
-           'SCML_global_Supervised', '__version__']
+           'MLKR', 'MMC', 'MMC_Supervised', 'SCML',
+           'SCML_Supervised', '__version__']

--- a/metric_learn/__init__.py
+++ b/metric_learn/__init__.py
@@ -18,5 +18,5 @@ from ._version import __version__
 __all__ = ['Constraints', 'Covariance', 'ITML', 'ITML_Supervised',
            'LMNN', 'LSML', 'LSML_Supervised', 'SDML',
            'SDML_Supervised', 'NCA', 'LFDA', 'RCA', 'RCA_Supervised',
-           'MLKR', 'MMC', 'MMC_Supervised', 'SCML_global', 
+           'MLKR', 'MMC', 'MMC_Supervised', 'SCML_global',
            'SCML_global_Supervised', '__version__']

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -554,9 +554,9 @@ class SCML_Supervised(_BaseSCML, TransformerMixin):
       warnings.warn("The number of basis is less than the number of classes, "
                     "which may lead to poor discriminative performance.")
     elif n_basis >= X.shape[0]*2*num_eig:
-      raise ValueError("The needed number of clusters to generate the selected"
-                       "number of basis is unfeasible to achieve as it is "
-                       "greater than the number of available samples")
+      raise ValueError("Not enough samples to generate %d LDA bases, n_basis"
+                       "should be smaller than %d" %
+                       (n_basis, X.shape[0]*2*num_eig))
 
     kmeans = KMeans(n_clusters=n_clusters, random_state=self.random_state,
                     algorithm='elkan').fit(X)

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -73,10 +73,10 @@ class _BaseSCML(MahalanobisMixin):
         # regularization part of obj function
         obj1 = np.sum(w)*self.beta
 
-      # Every triplet distance difference in the space given by L
-      # plus a slack of one
+        # Every triplet distance difference in the space given by L
+        # plus a slack of one
         slack_val = 1 + np.matmul(dist_diff, w.T)
-      # Mask of places with positive slack
+        # Mask of places with positive slack
         slack_mask = slack_val > 0
 
         # loss function of learning task part of obj function
@@ -96,13 +96,13 @@ class _BaseSCML(MahalanobisMixin):
       idx = rand_int[iter]
 
       slack_val = 1 + np.matmul(dist_diff[idx, :], w.T)
-
       slack_mask = np.squeeze(slack_val > 0, axis=1)
-      avg_grad_w = ((iter * avg_grad_w + np.sum(dist_diff[idx[slack_mask], :],
-                                                axis=0, keepdims=True))
-                    / (iter+1))
 
-      scale_f = -np.sqrt(iter+1) / (self.gamma*self.batch_size)
+      grad_w = np.sum(dist_diff[idx[slack_mask], :],
+                      axis=0, keepdims=True)/self.batch_size
+      avg_grad_w = (iter * avg_grad_w + grad_w) / (iter+1)
+
+      scale_f = -np.sqrt(iter+1) / self.gamma
 
       # proximal operator with negative trimming equivalent
       w = scale_f * np.minimum(avg_grad_w + self.beta, 0)

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -546,17 +546,17 @@ class SCML_Supervised(_BaseSCML, TransformerMixin):
       raise ValueError("n_basis should be an integer, instead it is of type %s"
                        % type(self.n_basis))
 
-    if n_basis < n_class:
-      warnings.warn("The number of basis is less than the number of classes,"
-                    " this will lead to less basis than the amount yielded by"
-                    " LDA")
-    elif n_basis >= X.shape[0]*2*num_eig:
-      raise ValueError("The selected number of basis needs a greater number of"
-                       " clusters than the number of available samples")
-
     # Number of clusters needed for 2 scales given the number of basis
     # yielded by every LDA
     n_clusters = int(np.ceil(n_basis/(2 * num_eig)))
+
+    if n_basis < n_class:
+      warnings.warn("The number of basis is less than the number of classes, "
+                    "which may lead to poor discriminative performance.")
+    elif n_basis >= X.shape[0]*2*num_eig:
+      raise ValueError("The needed number of clusters to generate the selected"
+                       "number of basis is unfeasible to achieve as it is "
+                       "greater than the number of available samples")
 
     kmeans = KMeans(n_clusters=n_clusters, random_state=self.random_state,
                     algorithm='elkan').fit(X)

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -43,15 +43,12 @@ class _BaseSCML(MahalanobisMixin):
     self.random_state = random_state
     super(_BaseSCML, self).__init__(preprocessor)
 
-  def _fit(self, triplets, X=None, basis=None, n_basis=None):
+  def _fit(self, triplets, basis=None, n_basis=None):
     """
     Optimization procedure to find a sparse vector of weights to
     construct the metric from the basis set. This is based on the
     dual averaging method.
     """
-
-    if X is not None:
-      triplets = X[triplets]
 
     # Currently prepare_inputs makes triplets contain points and not indices
     triplets = self._prepare_inputs(triplets, type_of_inputs='tuples')
@@ -475,7 +472,9 @@ class SCML_Supervised(_BaseSCML, TransformerMixin):
     triplets = constraints.generate_knntriplets(X, self.k_genuine,
                                                 self.k_impostor)
 
-    return self._fit(triplets, X, basis, n_basis)
+    triplets = X[triplets]
+
+    return self._fit(triplets, basis, n_basis)
 
   def _initialize_basis_supervised(self, X, y):
     """ TODO: complete function description

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -144,17 +144,17 @@ class _BaseSCML_global(MahalanobisMixin):
     """
 
     # get rid of inactive bases
-    active_idx = w > 0
-    w = w[active_idx]
-    basis = self.basis[np.squeeze(active_idx), :]
+    active_idx, = w > 0
+    w = w[..., active_idx]
+    basis = self.basis[active_idx, :]
 
     K, d = basis.shape
 
     if(K < d):  # if metric is low-rank
-      return basis*np.sqrt(w)[..., None]
+      return np.sqrt(w.T)*basis # equivalent to np.diag(np.sqrt(w)).dot(B)
 
     else:   # if metric is full rank
-      return np.linalg.cholesky(np.matmul(basis.T * w, basis, order='F')).T
+      return np.linalg.cholesky(np.matmul(basis.T, w.T*basis, order='F')).T
 
   def _to_index_points(self, triplets):
     shape = triplets.shape

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -22,7 +22,7 @@ class _BaseSCML(MahalanobisMixin):
   _authorized_basis = ['triplet_diffs']
 
   def __init__(self, beta=1e-5, basis='triplet_diffs', n_basis=None,
-               gamma=5e-3, max_iter=100000, output_iter=5000, batch_size=10,
+               gamma=5e-3, max_iter=10000, output_iter=500, batch_size=10,
                verbose=False, preprocessor=None, random_state=None):
     self.beta = beta
     self.basis = basis
@@ -66,12 +66,10 @@ class _BaseSCML(MahalanobisMixin):
     best_obj = np.inf
 
     rng = check_random_state(self.random_state)
-    max_iter = int(self.max_iter/self.batch_size)
-    output_iter = int(self.output_iter/self.batch_size)
     rand_int = rng.randint(low=0, high=n_triplets,
-                           size=(max_iter, self.batch_size))
-    for iter in range(max_iter):
-      if (iter + 1) % output_iter == 0:
+                           size=(self.max_iter, self.batch_size))
+    for iter in range(self.max_iter):
+      if (iter + 1) % self.output_iter == 0:
         # regularization part of obj function
         obj1 = np.sum(w)*self.beta
 
@@ -88,7 +86,7 @@ class _BaseSCML(MahalanobisMixin):
         if self.verbose:
           count = np.sum(slack_mask)
           print("[%s] iter %d\t obj %.6f\t num_imp %d" %
-                (self.__class__.__name__, (iter+1)*self.batch_size, obj, count))
+                (self.__class__.__name__, (iter+1), obj, count))
 
         # update the best
         if obj < best_obj:
@@ -469,7 +467,7 @@ class SCML_Supervised(_BaseSCML, TransformerMixin):
   _authorized_basis = _BaseSCML._authorized_basis + ['lda']
 
   def __init__(self, k_genuine=3, k_impostor=10, beta=1e-5, basis='lda',
-               n_basis=None, gamma=5e-3, max_iter=100000, output_iter=5000,
+               n_basis=None, gamma=5e-3, max_iter=10000, output_iter=500,
                batch_size=10, verbose=False, preprocessor=None,
                random_state=None):
     self.k_genuine = k_genuine

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -5,6 +5,7 @@ Sparse Compositional Metric Learning (SCML)
 from __future__ import print_function, absolute_import, division
 import numpy as np
 from .base_metric import _TripletsClassifierMixin, MahalanobisMixin
+from ._util import components_from_metric
 from sklearn.base import TransformerMixin
 from .constraints import Constraints
 from sklearn.preprocessing import normalize
@@ -121,6 +122,7 @@ class _BaseSCML(MahalanobisMixin):
       print("max iteration reached.")
 
     # return L matrix yielded from best weights
+    self.n_iter_ = iter
     self.components_ = self._components_from_basis_weights(basis, best_w)
 
     return self
@@ -170,7 +172,7 @@ class _BaseSCML(MahalanobisMixin):
       return np.sqrt(w.T)*basis  # equivalent to np.diag(np.sqrt(w)).dot(basis)
 
     else:   # if metric is full rank
-      return np.linalg.cholesky(np.matmul(basis.T, w.T*basis)).T
+      return components_from_metric(np.matmul(basis.T, w.T*basis))
 
   def _to_index_points(self, triplets):
     shape = triplets.shape

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -15,16 +15,6 @@ from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
 from sklearn.utils import check_array, check_random_state
 import warnings
 
-# hack around lack of where in older numpy versions
-try:
-  np.sum([[0, 1], [1, 1]], where=[False, True], axis=1)
-except TypeError:
-  def sum_where(X, where):
-    return np.sum(X[where])
-else:
-  def sum_where(X, where):
-    return np.sum(X, where=where)
-
 
 class _BaseSCML(MahalanobisMixin):
 
@@ -88,7 +78,7 @@ class _BaseSCML(MahalanobisMixin):
         slack_mask = slack_val > 0
 
         # loss function of learning task part of obj function
-        obj2 = sum_where(slack_val, slack_mask)/n_triplets
+        obj2 = np.sum(slack_val[slack_mask])/n_triplets
 
         obj = obj1 + obj2
         if self.verbose:

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -543,7 +543,7 @@ class SCML_Supervised(_BaseSCML, TransformerMixin):
 
     if self.n_basis is None:
       # TODO: Get a good default n_basis directive
-      n_basis = min(20*n_features, X.shape[0]*2*num_eig)
+      n_basis = min(20*n_features, X.shape[0]*2*num_eig - 1)
       warnings.warn('As no value for `n_basis` was selected, the number of '
                     'basis will be set to n_basis= %d' % n_basis)
 

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -177,11 +177,7 @@ class _BaseSCML_global(MahalanobisMixin):
   def _initialize_basis(self, triplets, X):
     """ TODO: complete function description
     """
-
-    if self.preprocessor is not None:
-      n_features = self.preprocessor.shape[1]
-    else:
-      n_features = triplets.shape[1]
+    n_features = X.shape[1]
 
     # TODO:
     # Add other options passed as string
@@ -510,12 +506,6 @@ class SCML_global_Supervised(_BaseSCML_global, TransformerMixin):
     # Number of clusters needed for 2 scales given the number of basis
     # yielded by every LDA
     n_clusters = int(np.ceil(n_basis/(2 * num_eig)))
-
-    if(n_clusters > X.shape[0]):
-      raise ValueError("There are not enough samples to yield the required"
-                       " amount of clusters for the selected number of basis,"
-                       " the current maximum is n_basis = %d" %
-                       X.shape[0]*2*num_eig)
 
     # TODO: maybe give acces to Kmeans jobs for faster computation?
     kmeans = KMeans(n_clusters=n_clusters, random_state=self.random_state,

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -546,9 +546,10 @@ class SCML_Supervised(_BaseSCML, TransformerMixin):
       raise ValueError("n_basis should be an integer, instead it is of type %s"
                        % type(self.n_basis))
 
-    if n_basis <= n_class:
-      raise ValueError("The number of basis should be greater than the"
-                       " number of classes")
+    if n_basis < n_class:
+      warnings.warn("The number of basis is less than the number of classes,"
+                    " this will lead to less basis than the amount yielded by"
+                    " LDA")
     elif n_basis >= X.shape[0]*2*num_eig:
       raise ValueError("The selected number of basis needs a greater number of"
                        " clusters than the number of available samples")

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -83,8 +83,8 @@ class _BaseSCML(MahalanobisMixin):
         obj = obj1 + obj2
         if self.verbose:
           count = np.sum(slack_mask)
-          print("[Global] iter %d\t obj %.6f\t num_imp %d" % (iter+1,
-                obj, count))
+          print("[%s] iter %d\t obj %.6f\t num_imp %d" %
+                (self.__class__.__name__, iter+1, obj, count))
 
         # update the best
         if obj < best_obj:
@@ -473,8 +473,8 @@ class SCML_Supervised(_BaseSCML, TransformerMixin):
     self.k_genuine = k_genuine
     self.k_impostor = k_impostor
     _BaseSCML.__init__(self, beta=beta, basis=basis, n_basis=n_basis,
-                       max_iter=max_iter, verbose=verbose,
-                       preprocessor=preprocessor,
+                       max_iter=max_iter, output_iter=output_iter,
+                       verbose=verbose, preprocessor=preprocessor,
                        random_state=random_state)
 
   def fit(self, X, y):

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -254,11 +254,11 @@ class _BaseSCML(MahalanobisMixin):
 
       # select n_features positive differences
       d_pos = diff_pos[rng.choice(n_triplets,
-                                  size=n_features, replace=False),:]
+                                  size=n_features, replace=False), :]
 
       # select n_features negative differences
       d_neg = diff_neg[rng.choice(n_triplets,
-                                  size=n_features, replace=False),:]
+                                  size=n_features, replace=False), :]
 
       # Yield matrix
       diff_sum = d_pos.T.dot(d_pos) - d_neg.T.dot(d_neg)

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -151,7 +151,7 @@ class _BaseSCML_global(MahalanobisMixin):
     K, d = basis.shape
 
     if(K < d):  # if metric is low-rank
-      return np.sqrt(w.T)*basis # equivalent to np.diag(np.sqrt(w)).dot(B)
+      return np.sqrt(w.T)*basis  # equivalent to np.diag(np.sqrt(w)).dot(B)
 
     else:   # if metric is full rank
       return np.linalg.cholesky(np.matmul(basis.T, w.T*basis, order='F')).T

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -593,7 +593,8 @@ class SCML_Supervised(_BaseSCML, TransformerMixin):
 
         # get k_class same class neighbors
         neigh.fit(X=X[sel_c])
-        neighbors = neigh.kneighbors(X=cX, n_neighbors=k_class[1, c],
+        # Only take the neighbors once for the bigest scale
+        neighbors = neigh.kneighbors(X=cX, n_neighbors=k_class[-1, c],
                                      return_distance=False)
 
         # add index set of neighbors for every cluster center for both scales

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -60,8 +60,15 @@ class _BaseSCML(MahalanobisMixin):
 
     n_triplets = triplets.shape[0]
 
+    # weight vector
     w = np.zeros((1, n_basis))
+    # avarage obj gradient wrt weights
     avg_grad_w = np.zeros((1, n_basis))
+
+    # l2 norm in time of all obj gradients wrt weights
+    ada_grad_w = np.zeros((1, n_basis))
+    # slack for not dividing by zero
+    delta = 0.001
 
     best_obj = np.inf
 
@@ -102,7 +109,9 @@ class _BaseSCML(MahalanobisMixin):
                       axis=0, keepdims=True)/self.batch_size
       avg_grad_w = (iter * avg_grad_w + grad_w) / (iter+1)
 
-      scale_f = -np.sqrt(iter+1) / self.gamma
+      ada_grad_w = np.sqrt(np.square(ada_grad_w) + np.square(grad_w))
+
+      scale_f = -(iter+1) / self.gamma / (delta + ada_grad_w)
 
       # proximal operator with negative trimming equivalent
       w = scale_f * np.minimum(avg_grad_w + self.beta, 0)

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -64,6 +64,7 @@ class _BaseSCML_global(MahalanobisMixin):
 
     best_obj = np.inf
 
+    rand_int = np.random.randint(low=0, high=sizeT, size=self.max_iter)
     for iter in range(self.max_iter):
       if (iter % self.output_iter == 0):
         # regularization part of obj function
@@ -92,9 +93,9 @@ class _BaseSCML_global(MahalanobisMixin):
       # TODO:
       # Maybe allow the usage of mini-batch opt?
 
-      idx = np.random.randint(low=0, high=sizeT)
+      idx = rand_int[iter]
 
-      slack_val = 1 + dist_diff[idx, :].dot(w.T)
+      slack_val = 1 + np.matmul(dist_diff[idx, :], w.T)
 
       if (slack_val > 0):
         avg_grad_w = (iter * avg_grad_w + dist_diff[idx, :]) / (iter+1)

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -268,7 +268,7 @@ class SCML_global(_BaseSCML_global, _TripletsClassifierMixin):
     self : object
       Returns the instance.
     """
-    return _BaseSCML_global._fit(triplets)
+    return self._fit(triplets)
 
 
 class SCML_global_Supervised(_BaseSCML_global, TransformerMixin):
@@ -370,10 +370,6 @@ class SCML_global_Supervised(_BaseSCML_global, TransformerMixin):
     """
     X, y = self._prepare_inputs(X, y, ensure_min_samples=2)
     self.preprocessor = X
-
-    # TODO:
-    # it can be a problem if fit is called more than once,
-    # should that case be handled?
 
     if(self.basis == "LDA"):
       self._generate_bases_LDA(X, y)

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -482,7 +482,7 @@ class SCML_global_Supervised(_BaseSCML_global, TransformerMixin):
     elif self.n_basis < n_class:
       raise ValueError("The number of basis should be greater than the"
                        " number of classes")
-    elif np.issubdtype(self.n_basis, np.integer):
+    elif isinstance(self.n_basis, int):
       n_basis = self.n_basis
     else:
       raise ValueError("n_basis should be an integer, instead it is of type %s"

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -18,11 +18,11 @@ import warnings
 try:
   np.sum([[0, 1], [1, 1]], where=[False, True], axis=1)
 except TypeError:
-  def sum_were(X, where):
-    return np.sum(X, where=where)
-else:
   def sum_where(X, where):
     return np.sum(X[where])
+else:
+  def sum_where(X, where):
+    return np.sum(X, where=where)
 
 
 class _BaseSCML_global(MahalanobisMixin):

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -124,7 +124,7 @@ class _BaseSCML(MahalanobisMixin):
 
     return self
 
-  def _compute_dist_diff(self, T, X, basis):
+  def _compute_dist_diff(self, triplets, X, basis):
     """
     Helper function to compute the distance difference of every triplet in the
     space yielded by the basis set.
@@ -132,24 +132,25 @@ class _BaseSCML(MahalanobisMixin):
     # Transformation of data by the basis set
     XB = np.matmul(X, basis.T)
 
-    lenT = T.shape[0]
+    n_triplets = triplets.shape[0]
     # get all positive and negative pairs with lowest index first
-    # np.array (2*lenT,2)
-    T_pairs_sorted = np.sort(np.vstack((T[:, [0, 1]], T[:, [0, 2]])),
-                             kind='stable')
+    # np.array (2*n_triplets,2)
+    triplets_pairs_sorted = np.sort(np.vstack((triplets[:, [0, 1]],
+                                               triplets[:, [0, 2]])),
+                                    kind='stable')
     # calculate all unique pairs and their indices
-    uniqPairs, indices = np.unique(T_pairs_sorted, return_inverse=True,
+    uniqPairs, indices = np.unique(triplets_pairs_sorted, return_inverse=True,
                                    axis=0)
     # calculate L2 distance acording to bases only for unique pairs
     dist = np.square(XB[uniqPairs[:, 0], :] - XB[uniqPairs[:, 1], :])
 
     # return the diference of distances between all positive and negative
     # pairs
-    return dist[indices[:lenT]] - dist[indices[lenT:]]
+    return dist[indices[:n_triplets]] - dist[indices[n_triplets:]]
 
   def _components_from_basis_weights(self, basis, w):
     """
-    get components matrix (L) from computed mahalanobis matrix
+    Get components matrix (L) from computed mahalanobis matrix.
     """
 
     # get rid of inactive bases
@@ -160,7 +161,7 @@ class _BaseSCML(MahalanobisMixin):
     n_basis, n_features = basis.shape
 
     if n_basis < n_features:  # if metric is low-rank
-      warnings.warn("The number of effective basis is less than the numbert of"
+      warnings.warn("The number of effective basis is less than the number of"
                     " features of the input, in consequence the learned "
                     "transformation reduces the dimension to %d." % n_basis)
       return np.sqrt(w.T)*basis  # equivalent to np.diag(np.sqrt(w)).dot(basis)

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -67,7 +67,7 @@ class _BaseSCML(MahalanobisMixin):
     rng = check_random_state(self.random_state)
     rand_int = rng.randint(low=0, high=n_triplets, size=self.max_iter)
     for iter in range(self.max_iter):
-      if iter % self.output_iter == 0:
+      if (iter + 1) % self.output_iter == 0:
         # regularization part of obj function
         obj1 = np.sum(w)*self.beta
 
@@ -83,7 +83,7 @@ class _BaseSCML(MahalanobisMixin):
         obj = obj1 + obj2
         if self.verbose:
           count = np.sum(slack_mask)
-          print("[Global] iter %d\t obj %.6f\t num_imp %d" % (iter,
+          print("[Global] iter %d\t obj %.6f\t num_imp %d" % (iter+1,
                 obj, count))
 
         # update the best

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -102,7 +102,7 @@ class _BaseSCML(MahalanobisMixin):
 
       ada_grad_w = np.sqrt(np.square(ada_grad_w) + np.square(grad_w))
 
-      scale_f = -(iter+1) / self.gamma / (delta + ada_grad_w)
+      scale_f = -(iter+1) / (self.gamma * (delta + ada_grad_w))
 
       # proximal operator with negative trimming equivalent
       w = scale_f * np.minimum(avg_grad_w + self.beta, 0)

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -238,9 +238,6 @@ class _BaseSCML_global(MahalanobisMixin):
                     "of points, only n_basis = %d will be generated" %
                     n_basis)
 
-    else:
-      n_basis = self.n_basis
-
     uniqPairs = X[uniqPairs]
 
     rng = check_random_state(self.random_state)

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -593,7 +593,7 @@ class SCML_Supervised(_BaseSCML, TransformerMixin):
 
         # get k_class same class neighbors
         neigh.fit(X=X[sel_c])
-        # Only take the neighbors once for the bigest scale
+        # Only take the neighbors once for the biggest scale
         neighbors = neigh.kneighbors(X=cX, n_neighbors=k_class[-1, c],
                                      return_distance=False)
 

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -479,7 +479,6 @@ class SCML_global_Supervised(_BaseSCML_global, TransformerMixin):
 
     # Compute basis for every cluster in second scale
     finish = num_eig * n_clusters
-    n_components = None
     lda = LinearDiscriminantAnalysis()
     for i in range(n_clusters):
         start = finish
@@ -488,10 +487,9 @@ class SCML_global_Supervised(_BaseSCML_global, TransformerMixin):
         # handle tail, as n_basis != n_clusters*2*n_eig
         if (finish > self.n_basis):
           finish = self.n_basis
-          n_components = finish-start
 
-        lda.fit(X[idx_set[i, :]], y[idx_set[i, :]], n_components=n_components)
+        lda.fit(X[idx_set[i, :]], y[idx_set[i, :]])
 
-        self.basis[start:finish, :] = normalize(lda.scalings_.T)
+        self.basis[start:finish, :] = normalize(lda.scalings_.T[:finish-start])
 
     return

--- a/metric_learn/scml.py
+++ b/metric_learn/scml.py
@@ -235,7 +235,7 @@ class _BaseSCML(MahalanobisMixin):
     # calculate all unique pairs and their indices
     uniqPairs, indices = np.unique(triplets_pairs_sorted, return_inverse=True,
                                    axis=0)
-    # calculate diferences only for unique pairs
+    # calculate differences only for unique pairs
     diff = X[uniqPairs[:, 0], :] - X[uniqPairs[:, 1], :]
 
     diff_pos = diff[indices[:n_triplets], :]
@@ -285,10 +285,11 @@ class _BaseSCML(MahalanobisMixin):
 class SCML(_BaseSCML, _TripletsClassifierMixin):
   """Sparse Compositional Metric Learning (SCML)
 
-  `SCML` learns a metric from triplet constraints by optimizing sparse
-  positive weights assigned to a set of `K` locally discriminative rank-one
-  PSD bases. This can be formulated as an optimization problem with only `K`
-  parameters, that can be solved with an efficient stochastic composite scheme.
+  `SCML` learns an squared Mahalanobis distance from triplet constraints by
+  optimizing sparse positive weights assigned to a set of :math:`K` rank-one
+  PSD bases. This can be formulated as an optimization problem with only
+  :math:`K` parameters, that can be solved with an efficient stochastic
+  composite scheme.
 
   Read more in the :ref:`User Guide <scml>`.
 

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -21,9 +21,9 @@ except ImportError:
 else:
   HAS_SKGGM = True
 from metric_learn import (LMNN, NCA, LFDA, Covariance, MLKR, MMC,
-                          SCML_global_Supervised, LSML_Supervised,
+                          SCML_Supervised, LSML_Supervised,
                           ITML_Supervised, SDML_Supervised, RCA_Supervised,
-                          MMC_Supervised, SDML, RCA, ITML, LSML, SCML_global,
+                          MMC_Supervised, SDML, RCA, ITML, LSML, SCML,
                           Constraints)
 # Import this specially for testing.
 from metric_learn.constraints import wrap_pairs
@@ -79,24 +79,24 @@ class TestCovariance(MetricTestCase):
 
 class TestSCML(MetricTestCase):
   def test_iris(self):
-    scml = SCML_global_Supervised()
+    scml = SCML_Supervised()
     scml.fit(self.iris_points, self.iris_labels)
 
     csep = class_separation(scml.transform(self.iris_points), self.iris_labels)
     self.assertLess(csep, 0.3)
 
   def test_bad_basis(self):
-    scml = SCML_global(basis='bad_basis')
+    scml = SCML(basis='bad_basis')
     triplets = np.ones((3, 3, 3))
     authorized_basis = ['triplet_diffs']
-    msg = ("`basis` must be '{}' or a numpy array of shape (n_basis, "
-           "n_features).".format("', '".join(authorized_basis)))
+    msg = ("`basis` must be one of the options '{}' or an array of shape "
+           "(n_basis, n_features).".format("', '".join(authorized_basis)))
     with pytest.raises(ValueError) as raised_error:
       scml.fit(triplets)
     assert msg == raised_error.value.args[0]
 
   def test_big_n_basis(self):
-    scml = SCML_global(n_basis=4)
+    scml = SCML(n_basis=4)
     triplets = np.ones((3, 3, 3))
     n_basis = 1
     msg = ("The selected number of basis is greater than the number of points"
@@ -115,7 +115,7 @@ class TestSCML(MetricTestCase):
 
     n_basis = 4.0
 
-    scml = SCML_global(n_basis=n_basis)
+    scml = SCML(n_basis=n_basis)
     msg = ("n_basis should be an integer, instead it is of type %s"
            % type(n_basis))
     with pytest.raises(ValueError) as raised_error:
@@ -123,14 +123,14 @@ class TestSCML(MetricTestCase):
     assert msg == raised_error.value.args[0]
 
   def test_bad_basis_supervised(self):
-    scml = SCML_global_Supervised(basis='bad_basis')
+    scml = SCML_Supervised(basis='bad_basis')
     X = np.array([[0, 0], [0, 1], [2, 0], [2, 1]])
     y = np.array([1, 0, 1, 0])
     authorized_basis = ['triplet_diffs']
     supervised_basis = ['LDA']
     authorized_basis = supervised_basis + authorized_basis
-    msg = ("`basis` must be '{}' or a numpy array of shape (n_basis, "
-           "n_features).".format("', '".join(authorized_basis)))
+    msg = ("`basis` must be one of the options '{}' or an array of shape "
+           "(n_basis, n_features).".format("', '".join(authorized_basis)))
     with pytest.raises(ValueError) as raised_error:
       scml.fit(X, y)
     assert msg == raised_error.value.args[0]
@@ -142,7 +142,7 @@ class TestSCML(MetricTestCase):
     labels, class_count = np.unique(y, return_counts=True)
     n_class = len(labels)
 
-    scml = SCML_global_Supervised(n_basis=n_class)
+    scml = SCML_Supervised(n_basis=n_class)
     msg = ("The number of basis should be greater than the number of classes")
     with pytest.raises(ValueError) as raised_error:
       scml.fit(X, y)
@@ -158,7 +158,7 @@ class TestSCML(MetricTestCase):
 
     n_basis = X.shape[0]*2*num_eig
 
-    scml = SCML_global_Supervised(n_basis=n_basis)
+    scml = SCML_Supervised(n_basis=n_basis)
     msg = ("The selected number of basis needs a greater number of clusters"
            " than the number of available samples")
     with pytest.raises(ValueError) as raised_error:
@@ -171,7 +171,7 @@ class TestSCML(MetricTestCase):
 
     n_basis = 4.0
 
-    scml = SCML_global_Supervised(n_basis=n_basis)
+    scml = SCML_Supervised(n_basis=n_basis)
     msg = ("n_basis should be an integer, instead it is of type %s"
            % type(n_basis))
     with pytest.raises(ValueError) as raised_error:
@@ -187,11 +187,10 @@ class TestSCML(MetricTestCase):
 
     basis = np.eye(3)
 
-    scml = SCML_global_Supervised(n_basis=3, basis=basis, k_genuine=1,
-                                  k_impostor=1)
+    scml = SCML_Supervised(n_basis=3, basis=basis, k_genuine=1, k_impostor=1)
 
-    msg = ('The input dimensionality ({}) of the given linear transformation '
-           '`init` must match the dimensionality of the given inputs `X` ({}).'
+    msg = ('The dimensionality ({}) of the provided bases must match the '
+           'dimensionality of the given inputs `X` ({}).'
            .format(basis.shape[1], X.shape[1]))
     with pytest.raises(ValueError) as raised_error:
       scml.fit(X, y)

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -117,11 +117,9 @@ class TestSCML(object):
                          [[2, 1], [0, 1], [2, 0]],
                          [[0, 0], [2, 0], [0, 1]],
                          [[2, 0], [0, 0], [2, 1]]])
-    n_basis = 1
     msg = ("The number of bases with nonzero weight is less than the "
            "number of features of the input, in consequence the "
-           "learned transformation reduces the dimension to %d."
-           % n_basis)
+           "learned transformation reduces the dimension to 1.")
     with pytest.warns(UserWarning) as raised_warning:
       scml.fit(triplets)
     assert msg == raised_warning[0].message.args[0]
@@ -135,7 +133,6 @@ class TestSCML(object):
                                                        [3, 3]]),
                                               np.array([1, 2, 3])))])
   def test_n_basis_wrong_type(self, estimator, data):
-
     n_basis = 4.0
     model = estimator(n_basis=n_basis)
     msg = ("n_basis should be an integer, instead it is of type %s"
@@ -149,7 +146,6 @@ class TestSCML(object):
     y = np.array([0, 0, 1, 1])
 
     n_class = 2
-
     scml = SCML_Supervised(n_basis=n_class-1)
     msg = ("The number of basis is less than the number of classes, which may"
            " lead to poor discriminative performance.")
@@ -162,9 +158,8 @@ class TestSCML(object):
     y = np.array([1, 2, 3])
 
     n_class = 3
-    num_eig = min(n_class-1, X.shape[1])
-
-    n_basis = X.shape[0]*2*num_eig
+    num_eig = min(n_class - 1, X.shape[1])
+    n_basis = X.shape[0] * 2 * num_eig
 
     scml = SCML_Supervised(n_basis=n_basis)
     msg = ("Not enough samples to generate %d LDA bases, n_basis"
@@ -184,7 +179,6 @@ class TestSCML(object):
     array is not consistent with the input
     """
     basis = np.eye(3)
-
     scml = estimator(n_basis=3, basis=basis)
 
     msg = ('The dimensionality ({}) of the provided bases must match the '
@@ -252,11 +246,9 @@ class TestSCML(object):
                                                 model.k_impostor)
     basis, n_basis = model._generate_bases_dist_diff(triplets, X)
 
-    expected_n_basis = n_features*80
-    expected_shape = (expected_n_basis, n_features)
-
+    expected_n_basis = n_features * 80
     assert n_basis == expected_n_basis
-    assert basis.shape == expected_shape
+    assert basis.shape == (expected_n_basis, n_features)
 
   @pytest.mark.parametrize('n_samples', [100, 500])
   @pytest.mark.parametrize('n_features', [10, 50, 100])
@@ -270,12 +262,10 @@ class TestSCML(object):
     model = SCML_Supervised()
     basis, n_basis = model._generate_bases_LDA(X, y)
 
-    num_eig = min(n_classes-1, n_features)
-    expected_n_basis = min(20*n_features, n_samples*2*num_eig - 1)
-    expected_shape = (expected_n_basis, n_features)
-
+    num_eig = min(n_classes - 1, n_features)
+    expected_n_basis = min(20 * n_features, n_samples * 2 * num_eig - 1)
     assert n_basis == expected_n_basis
-    assert basis.shape == expected_shape
+    assert basis.shape == (expected_n_basis, n_features)
 
   @pytest.mark.parametrize('name', ['max_iter', 'output_iter', 'batch_size',
                                     'n_basis'])
@@ -285,9 +275,8 @@ class TestSCML(object):
     scml = SCML(**d)
     triplets = np.array([[[0, 1], [2, 1], [0, 0]]])
 
-    msg = name
-    msg += (" should be an integer, instead it is of type"
-            " %s" % type(value))
+    msg = ("%s should be an integer, instead it is of type"
+           " %s" % (name, type(value)))
     with pytest.raises(ValueError) as raised_error:
       scml.fit(triplets)
     assert msg == raised_error.value.args[0]
@@ -300,9 +289,8 @@ class TestSCML(object):
     scml = SCML_Supervised(**d)
     X = np.array([[0, 0], [1, 1], [3, 3], [4, 4]])
     y = np.array([1, 1, 0, 0])
-    msg = name
-    msg += (" should be an integer, instead it is of type"
-            " %s" % type(value))
+    msg = ("%s should be an integer, instead it is of type"
+           " %s" % (name, type(value)))
     with pytest.raises(ValueError) as raised_error:
       scml.fit(X, y)
     assert msg == raised_error.value.args[0]

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -203,11 +203,11 @@ class TestSCML(object):
   def test_verbose(self, estimator, data, capsys):
     # assert there is proper output when verbose = True
     model = estimator(preprocessor=np.array([[0, 0], [1, 1], [2, 2], [3, 3]]),
-                      max_iter=1, verbose=True)
+                      max_iter=1, output_iter=1, verbose=True)
     model.fit(*data)
     out, _ = capsys.readouterr()
-    expected_out = ('[Global] iter 0\t obj 1.000000\t num_imp 8\n'
-                    'max iteration reached.\n')
+    expected_out = ('[%s] iter 1\t obj 1.000000\t num_imp 8\n'
+                    'max iteration reached.\n' % estimator.__name__)
     assert out == expected_out
 
   def test_triplet_diffs(self):

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -79,11 +79,11 @@ class TestCovariance(MetricTestCase):
 class TestSCML():
   def test_iris(self):
     X, y = load_iris(return_X_y=True)
-    scml = SCML_Supervised(n_basis=80, k_genuine=8, k_impostor=11,
+    scml = SCML_Supervised(n_basis=80, k_genuine=7, k_impostor=5,
                            random_state=42)
     scml.fit(X, y)
     csep = class_separation(scml.transform(X), y)
-    assert csep == 0.24555420119538296
+    assert csep < 0.23
 
   @pytest.mark.parametrize(('estimator', 'data', 'authorized_basis'),
                            [(SCML, (np.ones((3, 3, 3)),), ['triplet_diffs']),

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -236,7 +236,7 @@ class TestSCML(object):
     assert n_basis == expected_n_basis
     np.testing.assert_allclose(np.abs(basis), expected_basis)
 
-  @pytest.mark.parametrize('n_samples', [100, 500, 1000])
+  @pytest.mark.parametrize('n_samples', [100, 500])
   @pytest.mark.parametrize('n_features', [10, 50, 100])
   @pytest.mark.parametrize('n_classes', [5, 10, 15])
   def test_triplet_diffs(self, n_samples, n_features, n_classes):
@@ -257,7 +257,7 @@ class TestSCML(object):
     assert n_basis == expected_n_basis
     assert basis.shape == expected_shape
 
-  @pytest.mark.parametrize('n_samples', [100, 500, 1000])
+  @pytest.mark.parametrize('n_samples', [100, 500])
   @pytest.mark.parametrize('n_features', [10, 50, 100])
   @pytest.mark.parametrize('n_classes', [5, 10, 15])
   def test_lda(self, n_samples, n_features, n_classes):

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -76,7 +76,7 @@ class TestCovariance(MetricTestCase):
                     pseudo_inverse)
 
 
-class TestSCML():
+class TestSCML(object):
   def test_iris(self):
     X, y = load_iris(return_X_y=True)
     scml = SCML_Supervised(n_basis=80, k_genuine=7, k_impostor=5,
@@ -85,16 +85,16 @@ class TestSCML():
     csep = class_separation(scml.transform(X), y)
     assert csep < 0.23
 
-  @pytest.mark.parametrize(('estimator', 'data', 'authorized_basis'),
-                           [(SCML, (np.ones((3, 3, 3)),), ['triplet_diffs']),
+  @pytest.mark.parametrize(('estimator', 'data'),
+                           [(SCML, (np.ones((3, 3, 3)),)),
                             (SCML_Supervised, (np.array([[0, 0], [0, 1],
                                                          [2, 0], [2, 1]]),
-                                               np.array([1, 0, 1, 0])),
-                             ['triplet_diffs', 'lda'])])
-  def test_bad_basis(self, estimator, data, authorized_basis):
+                                               np.array([1, 0, 1, 0])))])
+  def test_bad_basis(self, estimator, data):
     model = estimator(basis='bad_basis')
     msg = ("`basis` must be one of the options '{}' or an array of shape "
-           "(n_basis, n_features).".format("', '".join(authorized_basis)))
+           "(n_basis, n_features)."
+           .format("', '".join(model._authorized_basis)))
     with pytest.raises(ValueError) as raised_error:
       model.fit(*data)
     assert msg == raised_error.value.args[0]

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -13,6 +13,7 @@ from numpy.testing import (assert_array_almost_equal, assert_array_equal,
 from sklearn.utils.testing import assert_warns_message
 from sklearn.exceptions import ConvergenceWarning, ChangedBehaviorWarning
 from sklearn.utils.validation import check_X_y
+from sklearn.preprocessing import StandardScaler
 try:
   from inverse_covariance import quic
   assert(quic)
@@ -85,6 +86,16 @@ class TestSCML(object):
     scml.fit(X, y)
     csep = class_separation(scml.transform(X), y)
     assert csep < 0.24
+
+  def test_big_n_features(self):
+    X, y = make_classification(n_samples=100, n_classes=3, n_features=60,
+                               n_informative=60, n_redundant=0, n_repeated=0,
+                               random_state=42)
+    X = StandardScaler().fit_transform(X)
+    scml = SCML_Supervised(random_state=42)
+    scml.fit(X, y)
+    csep = class_separation(scml.transform(X), y)
+    assert csep < 0.7
 
   @pytest.mark.parametrize(('estimator', 'data'),
                            [(SCML, (np.ones((3, 3, 3)),)),

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -217,6 +217,8 @@ class TestSCML(object):
     triplets = np.array([[0, 1, 2], [0, 1, 3], [1, 0, 2], [1, 0, 3],
                          [2, 3, 1], [2, 3, 0], [3, 2, 1], [3, 2, 0]])
     basis, n_basis = model._generate_bases_dist_diff(triplets, X)
+    # All points are along the same line, so the only possible basis will be
+    # the vector along that line normalized.
     expected_basis = np.ones((expected_n_basis, 2))/np.sqrt(2)
     assert n_basis == expected_n_basis
     np.testing.assert_allclose(basis, expected_basis)
@@ -227,6 +229,9 @@ class TestSCML(object):
     X = np.array([[0, 0], [1, 1], [2, 2], [3, 3]])
     y = np.array([0, 0, 1, 1])
     basis, n_basis = model._generate_bases_LDA(X, y)
+    # All points are along the same line, so the only possible basis will be
+    # the vector along that line normalized. In this case it is possible to
+    # obtain it with positive or negative orientations.
     expected_basis = np.ones((expected_n_basis, 2))/np.sqrt(2)
     assert n_basis == expected_n_basis
     np.testing.assert_allclose(np.abs(basis), expected_basis)

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -97,8 +97,8 @@ class TestSCML(MetricTestCase):
 
   def test_big_n_basis(self):
     scml = SCML(n_basis=4)
-    triplets = np.ones((3, 3, 3))
-    n_basis = 1
+    triplets = np.random.rand(3, 3, 3)
+    n_basis = 3
     msg = ("The selected number of basis is greater than the number of points"
            ", only n_basis = %d will be generated" % n_basis)
     with pytest.warns(UserWarning) as raised_warning:
@@ -126,9 +126,7 @@ class TestSCML(MetricTestCase):
     scml = SCML_Supervised(basis='bad_basis')
     X = np.array([[0, 0], [0, 1], [2, 0], [2, 1]])
     y = np.array([1, 0, 1, 0])
-    authorized_basis = ['triplet_diffs']
-    supervised_basis = ['LDA']
-    authorized_basis = supervised_basis + authorized_basis
+    authorized_basis = ['triplet_diffs', 'LDA']
     msg = ("`basis` must be one of the options '{}' or an array of shape "
            "(n_basis, n_features).".format("', '".join(authorized_basis)))
     with pytest.raises(ValueError) as raised_error:

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -133,16 +133,18 @@ class TestSCML(object):
     assert msg == raised_error.value.args[0]
 
   def test_small_n_basis_lda(self):
-    X = np.array([[0, 0], [1, 1], [3, 3]])
-    y = np.array([1, 2, 3])
+    X = np.array([[0, 0], [1, 1], [2, 2], [3, 3]])
+    y = np.array([0, 0, 1, 1])
 
-    n_class = 3
+    n_class = 2
 
-    scml = SCML_Supervised(n_basis=n_class)
-    msg = ("The number of basis should be greater than the number of classes")
-    with pytest.raises(ValueError) as raised_error:
+    scml = SCML_Supervised(n_basis=n_class-1)
+    msg = ("The number of basis is less than the number of classes,"
+           " this will lead to less basis than the amount yielded by"
+           " LDA")
+    with pytest.warns(UserWarning) as raised_warning:
       scml.fit(X, y)
-    assert msg == raised_error.value.args[0]
+    assert msg == raised_warning[0].message.args[0]
 
   def test_big_n_basis_lda(self):
     X = np.array([[0, 0], [1, 1], [3, 3]])

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -167,9 +167,9 @@ class TestSCML(object):
     n_basis = X.shape[0]*2*num_eig
 
     scml = SCML_Supervised(n_basis=n_basis)
-    msg = ("The needed number of clusters to generate the selected"
-           "number of basis is unfeasible to achieve as it is "
-           "greater than the number of available samples")
+    msg = ("Not enough samples to generate %d LDA bases, n_basis"
+           "should be smaller than %d" %
+           (n_basis, n_basis))
     with pytest.raises(ValueError) as raised_error:
       scml.fit(X, y)
     assert msg == raised_error.value.args[0]

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -199,6 +199,27 @@ class TestSCML(object):
                     'max iteration reached.\n')
     assert out == expected_out
 
+  def test_triplet_diffs(self):
+    expected_n_basis = 10
+    model = SCML_Supervised(n_basis=expected_n_basis)
+    X = np.array([[0, 0], [1, 1], [2, 2], [3, 3]])
+    triplets = np.array([[0, 1, 2], [0, 1, 3], [1, 0, 2], [1, 0, 3],
+                         [2, 3, 1], [2, 3, 0], [3, 2, 1], [3, 2, 0]])
+    basis, n_basis = model._generate_bases_dist_diff(triplets, X)
+    expected_basis = np.ones((expected_n_basis, 2))/np.sqrt(2)
+    assert n_basis == expected_n_basis
+    np.testing.assert_allclose(basis, expected_basis)
+
+  def test_lda(self):
+    expected_n_basis = 7
+    model = SCML_Supervised(n_basis=expected_n_basis)
+    X = np.array([[0, 0], [1, 1], [2, 2], [3, 3]])
+    y = np.array([0, 0, 1, 1])
+    basis, n_basis = model._generate_bases_LDA(X, y)
+    expected_basis = np.ones((expected_n_basis, 2))/np.sqrt(2)
+    assert n_basis == expected_n_basis
+    np.testing.assert_allclose(np.abs(basis), expected_basis)
+
 
 class TestLSML(MetricTestCase):
   def test_iris(self):

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -203,8 +203,8 @@ class TestSCML(object):
   def test_verbose(self, estimator, data, capsys):
     # assert there is proper output when verbose = True
     model = estimator(preprocessor=np.array([[0, 0], [1, 1], [2, 2], [3, 3]]),
-                      max_iter=1, output_iter=1, batch_size=1, basis='triplet_diffs',
-                      random_state=42, verbose=True)
+                      max_iter=1, output_iter=1, batch_size=1,
+                      basis='triplet_diffs', random_state=42, verbose=True)
     model.fit(*data)
     out, _ = capsys.readouterr()
     expected_out = ('[%s] iter 1\t obj 0.569946\t num_imp 2\n'

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -283,10 +283,7 @@ class TestSCML(object):
     value = 1.0
     d = {name: value}
     scml = SCML(**d)
-    triplets = np.array([[[0, 1], [2, 1], [0, 0]],
-                         [[2, 1], [0, 1], [2, 0]],
-                         [[0, 0], [2, 0], [0, 1]],
-                         [[2, 0], [0, 0], [2, 1]]])
+    triplets = np.array([[[0, 1], [2, 1], [0, 0]]])
 
     msg = name
     msg += (" should be an integer, instead it is of type"
@@ -312,10 +309,7 @@ class TestSCML(object):
 
   def test_large_output_iter(self):
     scml = SCML(max_iter=1, output_iter=2)
-    triplets = np.array([[[0, 1], [2, 1], [0, 0]],
-                         [[2, 1], [0, 1], [2, 0]],
-                         [[0, 0], [2, 0], [0, 1]],
-                         [[2, 0], [0, 0], [2, 1]]])
+    triplets = np.array([[[0, 1], [2, 1], [0, 0]]])
     msg = ("The value of output_iter must be equal or smaller than"
            " max_iter.")
 

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -203,7 +203,7 @@ class TestSCML(object):
   def test_verbose(self, estimator, data, capsys):
     # assert there is proper output when verbose = True
     model = estimator(preprocessor=np.array([[0, 0], [1, 1], [2, 2], [3, 3]]),
-                      max_iter=1, output_iter=1, verbose=True)
+                      max_iter=1, output_iter=1, batch_size=1, verbose=True)
     model.fit(*data)
     out, _ = capsys.readouterr()
     expected_out = ('[%s] iter 1\t obj 1.000000\t num_imp 8\n'

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -178,6 +178,25 @@ class TestSCML(MetricTestCase):
       scml.fit(X, y)
     assert msg == raised_error.value.args[0]
 
+  def test_array_basis_supervised(self):
+    """ Test that the proper error is raised when the shape of the input basis
+    array is not consistent with the input
+    """
+    X = np.array([[0, 0], [0, 1], [2, 0], [2, 1]])
+    y = np.array([1, 0, 1, 0])
+
+    basis = np.eye(3)
+
+    scml = SCML_global_Supervised(n_basis=3, basis=basis, k_genuine=1,
+                                  k_impostor=1)
+
+    msg = ('The input dimensionality ({}) of the given linear transformation '
+           '`init` must match the dimensionality of the given inputs `X` ({}).'
+           .format(basis.shape[1], X.shape[1]))
+    with pytest.raises(ValueError) as raised_error:
+      scml.fit(X, y)
+    assert msg == raised_error.value.args[0]
+
 
 class TestLSML(MetricTestCase):
   def test_iris(self):

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -77,13 +77,14 @@ class TestCovariance(MetricTestCase):
 
 
 class TestSCML(object):
-  def test_iris(self):
+  @pytest.mark.parametrize('basis', ('lda', 'triplet_diffs'))
+  def test_iris(self, basis):
     X, y = load_iris(return_X_y=True)
-    scml = SCML_Supervised(n_basis=80, k_genuine=7, k_impostor=5,
+    scml = SCML_Supervised(basis=basis, n_basis=85, k_genuine=7, k_impostor=5,
                            random_state=42)
     scml.fit(X, y)
     csep = class_separation(scml.transform(X), y)
-    assert csep < 0.23
+    assert csep < 0.24
 
   @pytest.mark.parametrize(('estimator', 'data'),
                            [(SCML, (np.ones((3, 3, 3)),)),

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -180,6 +180,22 @@ class TestSCML(object):
       scml.fit(*data)
     assert msg == raised_error.value.args[0]
 
+  @pytest.mark.parametrize(('estimator', 'data'),
+                           [(SCML, (np.array([[0, 1, 2], [0, 1, 3], [1, 0, 2],
+                                              [1, 0, 3], [2, 3, 1], [2, 3, 0],
+                                              [3, 2, 1], [3, 2, 0]]),)),
+                           (SCML_Supervised, (np.array([0, 1, 2, 3]),
+                                              np.array([0, 0, 1, 1])))])
+  def test_verbose(self, estimator, data, capsys):
+    # assert there is proper output when verbose = True
+    model = estimator(preprocessor=np.array([[0, 0], [1, 1], [2, 2], [3, 3]]),
+                      max_iter=1, verbose=True)
+    model.fit(*data)
+    out, _ = capsys.readouterr()
+    expected_out = ('[Global] iter 0\t obj 1.000000\t num_imp 8\n'
+                    'max iteration reached.\n')
+    assert out == expected_out
+
 
 class TestLSML(MetricTestCase):
   def test_iris(self):

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -98,9 +98,11 @@ class TestSCML(MetricTestCase):
   def test_big_n_basis(self):
     scml = SCML(n_basis=4)
     triplets = np.random.rand(3, 3, 3)
-    n_basis = 3
-    msg = ("The selected number of basis is greater than the number of points"
-           ", only n_basis = %d will be generated" % n_basis)
+    n_basis = 1
+    msg = ("The number of bases with nonzero weight is less than the "
+           "number of features of the input, in consequence the "
+           "learned transformation reduces the dimension to %d."
+           % n_basis)
     with pytest.warns(UserWarning) as raised_warning:
       scml.fit(triplets)
     assert msg == raised_warning[0].message.args[0]
@@ -126,7 +128,7 @@ class TestSCML(MetricTestCase):
     scml = SCML_Supervised(basis='bad_basis')
     X = np.array([[0, 0], [0, 1], [2, 0], [2, 1]])
     y = np.array([1, 0, 1, 0])
-    authorized_basis = ['triplet_diffs', 'LDA']
+    authorized_basis = ['triplet_diffs', 'lda']
     msg = ("`basis` must be one of the options '{}' or an array of shape "
            "(n_basis, n_features).".format("', '".join(authorized_basis)))
     with pytest.raises(ValueError) as raised_error:
@@ -188,7 +190,7 @@ class TestSCML(MetricTestCase):
     scml = SCML_Supervised(n_basis=3, basis=basis, k_genuine=1, k_impostor=1)
 
     msg = ('The dimensionality ({}) of the provided bases must match the '
-           'dimensionality of the given inputs `X` ({}).'
+           'dimensionality of the data ({}).'
            .format(basis.shape[1], X.shape[1]))
     with pytest.raises(ValueError) as raised_error:
       scml.fit(X, y)

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -140,9 +140,8 @@ class TestSCML(object):
     n_class = 2
 
     scml = SCML_Supervised(n_basis=n_class-1)
-    msg = ("The number of basis is less than the number of classes,"
-           " this will lead to less basis than the amount yielded by"
-           " LDA")
+    msg = ("The number of basis is less than the number of classes, which may"
+           " lead to poor discriminative performance.")
     with pytest.warns(UserWarning) as raised_warning:
       scml.fit(X, y)
     assert msg == raised_warning[0].message.args[0]
@@ -157,8 +156,9 @@ class TestSCML(object):
     n_basis = X.shape[0]*2*num_eig
 
     scml = SCML_Supervised(n_basis=n_basis)
-    msg = ("The selected number of basis needs a greater number of clusters"
-           " than the number of available samples")
+    msg = ("The needed number of clusters to generate the selected"
+           "number of basis is unfeasible to achieve as it is "
+           "greater than the number of available samples")
     with pytest.raises(ValueError) as raised_error:
       scml.fit(X, y)
     assert msg == raised_error.value.args[0]

--- a/test/test_base_metric.py
+++ b/test/test_base_metric.py
@@ -5,7 +5,7 @@ import metric_learn
 import numpy as np
 from sklearn import clone
 from sklearn.utils.testing import set_random_state
-from test.test_utils import ids_metric_learners, metric_learners
+from test.test_utils import ids_metric_learners, metric_learners, remove_y
 
 
 def remove_spaces(s):
@@ -135,12 +135,12 @@ def test_get_metric_is_independent_from_metric_learner(estimator,
 
   # we fit the metric learner on it and then we compute the metric on some
   # points
-  model.fit(input_data, labels)
+  model.fit(*remove_y(model, input_data, labels))
   metric = model.get_metric()
   score = metric(X[0], X[1])
 
   # then we refit the estimator on another dataset
-  model.fit(np.sin(input_data), labels)
+  model.fit(*remove_y(model, np.sin(input_data), labels))
 
   # we recompute the distance between the two points: it should be the same
   score_bis = metric(X[0], X[1])
@@ -155,7 +155,7 @@ def test_get_metric_raises_error(estimator, build_dataset):
   input_data, labels, _, X = build_dataset()
   model = clone(estimator)
   set_random_state(model)
-  model.fit(input_data, labels)
+  model.fit(*remove_y(model, input_data, labels))
   metric = model.get_metric()
 
   list_test_get_metric_raises = [(X[0].tolist() + [5.2], X[1]),  # vectors with
@@ -178,7 +178,7 @@ def test_get_metric_works_does_not_raise(estimator, build_dataset):
   input_data, labels, _, X = build_dataset()
   model = clone(estimator)
   set_random_state(model)
-  model.fit(input_data, labels)
+  model.fit(*remove_y(model, input_data, labels))
   metric = model.get_metric()
 
   list_test_get_metric_doesnt_raise = [(X[0], X[1]),
@@ -210,20 +210,20 @@ def test_n_components(estimator, build_dataset):
   if hasattr(model, 'n_components'):
     set_random_state(model)
     model.set_params(n_components=None)
-    model.fit(input_data, labels)
+    model.fit(*remove_y(model, input_data, labels))
     assert model.components_.shape == (X.shape[1], X.shape[1])
 
     model = clone(estimator)
     set_random_state(model)
     model.set_params(n_components=X.shape[1] - 1)
-    model.fit(input_data, labels)
+    model.fit(*remove_y(model, input_data, labels))
     assert model.components_.shape == (X.shape[1] - 1, X.shape[1])
 
     model = clone(estimator)
     set_random_state(model)
     model.set_params(n_components=X.shape[1] + 1)
     with pytest.raises(ValueError) as expected_err:
-      model.fit(input_data, labels)
+      model.fit(*remove_y(model, input_data, labels))
     assert (str(expected_err.value) ==
             'Invalid n_components, must be in [1, {}]'.format(X.shape[1]))
 
@@ -231,7 +231,7 @@ def test_n_components(estimator, build_dataset):
     set_random_state(model)
     model.set_params(n_components=0)
     with pytest.raises(ValueError) as expected_err:
-      model.fit(input_data, labels)
+      model.fit(*remove_y(model, input_data, labels))
     assert (str(expected_err.value) ==
             'Invalid n_components, must be in [1, {}]'.format(X.shape[1]))
 

--- a/test/test_mahalanobis_mixin.py
+++ b/test/test_mahalanobis_mixin.py
@@ -15,11 +15,12 @@ from sklearn.utils.testing import set_random_state
 
 from metric_learn._util import make_context, _initialize_metric_mahalanobis
 from metric_learn.base_metric import (_QuadrupletsClassifierMixin,
+                                      _TripletsClassifierMixin,
                                       _PairsClassifierMixin)
 from metric_learn.exceptions import NonPSDError
 
 from test.test_utils import (ids_metric_learners, metric_learners,
-                             remove_y_quadruplets, ids_classifiers)
+                             remove_y, ids_classifiers)
 
 RNG = check_random_state(0)
 
@@ -33,7 +34,7 @@ def test_score_pairs_pairwise(estimator, build_dataset):
   X = X[:n_samples]
   model = clone(estimator)
   set_random_state(model)
-  model.fit(*remove_y_quadruplets(estimator, input_data, labels))
+  model.fit(*remove_y(estimator, input_data, labels))
 
   pairwise = model.score_pairs(np.array(list(product(X, X))))\
       .reshape(n_samples, n_samples)
@@ -57,7 +58,7 @@ def test_score_pairs_toy_example(estimator, build_dataset):
     X = X[:n_samples]
     model = clone(estimator)
     set_random_state(model)
-    model.fit(*remove_y_quadruplets(estimator, input_data, labels))
+    model.fit(*remove_y(estimator, input_data, labels))
     pairs = np.stack([X[:10], X[10:20]], axis=1)
     embedded_pairs = pairs.dot(model.components_.T)
     distances = np.sqrt(np.sum((embedded_pairs[:, 1] -
@@ -73,7 +74,7 @@ def test_score_pairs_finite(estimator, build_dataset):
   input_data, labels, _, X = build_dataset()
   model = clone(estimator)
   set_random_state(model)
-  model.fit(*remove_y_quadruplets(estimator, input_data, labels))
+  model.fit(*remove_y(estimator, input_data, labels))
   pairs = np.array(list(product(X, X)))
   assert np.isfinite(model.score_pairs(pairs)).all()
 
@@ -87,7 +88,7 @@ def test_score_pairs_dim(estimator, build_dataset):
   input_data, labels, _, X = build_dataset()
   model = clone(estimator)
   set_random_state(model)
-  model.fit(*remove_y_quadruplets(estimator, input_data, labels))
+  model.fit(*remove_y(estimator, input_data, labels))
   tuples = np.array(list(product(X, X)))
   assert model.score_pairs(tuples).shape == (tuples.shape[0],)
   context = make_context(estimator)
@@ -118,7 +119,7 @@ def test_embed_toy_example(estimator, build_dataset):
     X = X[:n_samples]
     model = clone(estimator)
     set_random_state(model)
-    model.fit(*remove_y_quadruplets(estimator, input_data, labels))
+    model.fit(*remove_y(estimator, input_data, labels))
     embedded_points = X.dot(model.components_.T)
     assert_array_almost_equal(model.transform(X), embedded_points)
 
@@ -130,7 +131,7 @@ def test_embed_dim(estimator, build_dataset):
   input_data, labels, _, X = build_dataset()
   model = clone(estimator)
   set_random_state(model)
-  model.fit(*remove_y_quadruplets(estimator, input_data, labels))
+  model.fit(*remove_y(estimator, input_data, labels))
   assert model.transform(X).shape == X.shape
 
   # assert that ValueError is thrown if input shape is 1D
@@ -144,7 +145,7 @@ def test_embed_dim(estimator, build_dataset):
   # we test that the shape is also OK when doing dimensionality reduction
   if hasattr(model, 'n_components'):
     model.set_params(n_components=2)
-    model.fit(*remove_y_quadruplets(estimator, input_data, labels))
+    model.fit(*remove_y(estimator, input_data, labels))
     assert model.transform(X).shape == (X.shape[0], 2)
     # assert that ValueError is thrown if input shape is 1D
     with pytest.raises(ValueError) as raised_error:
@@ -159,7 +160,7 @@ def test_embed_finite(estimator, build_dataset):
   input_data, labels, _, X = build_dataset()
   model = clone(estimator)
   set_random_state(model)
-  model.fit(*remove_y_quadruplets(estimator, input_data, labels))
+  model.fit(*remove_y(estimator, input_data, labels))
   assert np.isfinite(model.transform(X)).all()
 
 
@@ -170,7 +171,7 @@ def test_embed_is_linear(estimator, build_dataset):
   input_data, labels, _, X = build_dataset()
   model = clone(estimator)
   set_random_state(model)
-  model.fit(*remove_y_quadruplets(estimator, input_data, labels))
+  model.fit(*remove_y(estimator, input_data, labels))
   assert_array_almost_equal(model.transform(X[:10] + X[10:20]),
                             model.transform(X[:10]) +
                             model.transform(X[10:20]))
@@ -189,7 +190,7 @@ def test_get_metric_equivalent_to_explicit_mahalanobis(estimator,
   input_data, labels, _, X = build_dataset()
   model = clone(estimator)
   set_random_state(model)
-  model.fit(*remove_y_quadruplets(estimator, input_data, labels))
+  model.fit(*remove_y(estimator, input_data, labels))
   metric = model.get_metric()
   n_features = X.shape[1]
   a, b = (rng.randn(n_features), rng.randn(n_features))
@@ -208,7 +209,7 @@ def test_get_metric_is_pseudo_metric(estimator, build_dataset):
   input_data, labels, _, X = build_dataset()
   model = clone(estimator)
   set_random_state(model)
-  model.fit(*remove_y_quadruplets(estimator, input_data, labels))
+  model.fit(*remove_y(estimator, input_data, labels))
   metric = model.get_metric()
 
   n_features = X.shape[1]
@@ -234,7 +235,7 @@ def test_metric_raises_deprecation_warning(estimator, build_dataset):
   input_data, labels, _, X = build_dataset()
   model = clone(estimator)
   set_random_state(model)
-  model.fit(*remove_y_quadruplets(estimator, input_data, labels))
+  model.fit(*remove_y(estimator, input_data, labels))
 
   with pytest.warns(DeprecationWarning) as raised_warning:
     model.metric()
@@ -251,7 +252,7 @@ def test_get_metric_compatible_with_scikit_learn(estimator, build_dataset):
   input_data, labels, _, X = build_dataset()
   model = clone(estimator)
   set_random_state(model)
-  model.fit(*remove_y_quadruplets(estimator, input_data, labels))
+  model.fit(*remove_y(estimator, input_data, labels))
   clustering = DBSCAN(metric=model.get_metric())
   clustering.fit(X)
 
@@ -264,7 +265,7 @@ def test_get_squared_metric(estimator, build_dataset):
   input_data, labels, _, X = build_dataset()
   model = clone(estimator)
   set_random_state(model)
-  model.fit(*remove_y_quadruplets(estimator, input_data, labels))
+  model.fit(*remove_y(estimator, input_data, labels))
   metric = model.get_metric()
 
   n_features = X.shape[1]
@@ -284,7 +285,7 @@ def test_components_is_2D(estimator, build_dataset):
   model = clone(estimator)
   set_random_state(model)
   # test that it works for X.shape[1] features
-  model.fit(*remove_y_quadruplets(estimator, input_data, labels))
+  model.fit(*remove_y(estimator, input_data, labels))
   assert model.components_.shape == (X.shape[1], X.shape[1])
 
   # test that it works for 1 feature
@@ -298,12 +299,18 @@ def test_components_is_2D(estimator, build_dataset):
       to_keep = np.where(np.abs(diffs.ravel()) > 1e-9)
       trunc_data = trunc_data[to_keep]
       labels = labels[to_keep]
+  if isinstance(estimator, _TripletsClassifierMixin):
+    for slice_idx in [[0, 1], [0, 2]]:
+      pairs = trunc_data[:, slice_idx, :]
+      diffs = pairs[:, 1, :] - pairs[:, 0, :]
+      to_keep = np.abs(diffs.ravel()) > 1e-9
+      trunc_data = trunc_data[to_keep]
   elif isinstance(estimator, _PairsClassifierMixin):
     diffs = trunc_data[:, 1, :] - trunc_data[:, 0, :]
     to_keep = np.where(np.abs(diffs.ravel()) > 1e-9)
     trunc_data = trunc_data[to_keep]
     labels = labels[to_keep]
-  model.fit(*remove_y_quadruplets(estimator, trunc_data, labels))
+  model.fit(*remove_y(estimator, trunc_data, labels))
   assert model.components_.shape == (1, 1)  # the components must be 2D
 
 
@@ -735,9 +742,9 @@ def test_deterministic_initialization(estimator, build_dataset):
     model.set_params(prior='random')
   model1 = clone(model)
   set_random_state(model1, 42)
-  model1 = model1.fit(input_data, labels)
+  model1 = model1.fit(*remove_y(model, input_data, labels))
   model2 = clone(model)
   set_random_state(model2, 42)
-  model2 = model2.fit(input_data, labels)
+  model2 = model2.fit(*remove_y(model, input_data, labels))
   np.testing.assert_allclose(model1.get_mahalanobis_matrix(),
                              model2.get_mahalanobis_matrix())

--- a/test/test_mahalanobis_mixin.py
+++ b/test/test_mahalanobis_mixin.py
@@ -292,24 +292,23 @@ def test_components_is_2D(estimator, build_dataset):
   trunc_data = input_data[..., :1]
   # we drop duplicates that might have been formed, i.e. of the form
   # aabc or abcc or aabb for quadruplets, and aa for pairs.
+
   if isinstance(estimator, _QuadrupletsClassifierMixin):
-    for slice_idx in [slice(0, 2), slice(2, 4)]:
-      pairs = trunc_data[:, slice_idx, :]
-      diffs = pairs[:, 1, :] - pairs[:, 0, :]
-      to_keep = np.where(np.abs(diffs.ravel()) > 1e-9)
-      trunc_data = trunc_data[to_keep]
-      labels = labels[to_keep]
-  if isinstance(estimator, _TripletsClassifierMixin):
-    for slice_idx in [[0, 1], [0, 2]]:
-      pairs = trunc_data[:, slice_idx, :]
-      diffs = pairs[:, 1, :] - pairs[:, 0, :]
-      to_keep = np.abs(diffs.ravel()) > 1e-9
-      trunc_data = trunc_data[to_keep]
+    pairs_idx = [[0, 1], [2, 3]]
+  elif isinstance(estimator, _TripletsClassifierMixin):
+    pairs_idx = [[0, 1], [0, 2]]
   elif isinstance(estimator, _PairsClassifierMixin):
-    diffs = trunc_data[:, 1, :] - trunc_data[:, 0, :]
-    to_keep = np.where(np.abs(diffs.ravel()) > 1e-9)
+    pairs_idx = [[0, 1]]
+  else:
+    pairs_idx = []
+
+  for pair_idx in pairs_idx:
+    pairs = trunc_data[:, pair_idx, :]
+    diffs = pairs[:, 1, :] - pairs[:, 0, :]
+    to_keep = np.abs(diffs.ravel()) > 1e-9
     trunc_data = trunc_data[to_keep]
     labels = labels[to_keep]
+
   model.fit(*remove_y(estimator, trunc_data, labels))
   assert model.components_.shape == (1, 1)  # the components must be 2D
 

--- a/test/test_sklearn_compat.py
+++ b/test/test_sklearn_compat.py
@@ -10,7 +10,8 @@ from sklearn.utils.testing import (assert_allclose_dense_sparse,
 
 from metric_learn import (Covariance, LFDA, LMNN, MLKR, NCA,
                           ITML_Supervised, LSML_Supervised,
-                          MMC_Supervised, RCA_Supervised, SDML_Supervised)
+                          MMC_Supervised, RCA_Supervised, SDML_Supervised,
+                          SCML_Supervised)
 from sklearn import clone
 import numpy as np
 from sklearn.model_selection import (cross_val_score, cross_val_predict,
@@ -78,6 +79,9 @@ class TestSklearnCompat(unittest.TestCase):
 
   def test_rca(self):
     check_estimator(Stable_RCA_Supervised)
+
+  def test_scml(self):
+    check_estimator(SCML_Supervised)
 
 
 RNG = check_random_state(0)

--- a/test/test_sklearn_compat.py
+++ b/test/test_sklearn_compat.py
@@ -22,7 +22,6 @@ from test.test_utils import (metric_learners, ids_metric_learners,
                              mock_preprocessor, tuples_learners,
                              ids_tuples_learners, pairs_learners,
                              ids_pairs_learners, remove_y,
-                             triplets_learners, quadruplets_learners,
                              metric_learners_pipeline,
                              ids_metric_learners_pipeline)
 
@@ -353,7 +352,7 @@ def test_pipeline_consistency(estimator, build_dataset,
 
   estimator = clone(estimator)
   estimator.set_params(preprocessor=preprocessor,
-                        **make_random_state(estimator, False))
+                       **make_random_state(estimator, False))
   pipeline = make_pipeline(estimator)
   estimator.fit(input_data, y)
   estimator.set_params(preprocessor=preprocessor)

--- a/test/test_triplets_classifiers.py
+++ b/test/test_triplets_classifiers.py
@@ -14,7 +14,7 @@ import numpy as np
 def test_predict_only_one_or_minus_one(estimator, build_dataset,
                                        with_preprocessor):
   """Test that all predicted values are either +1 or -1"""
-  input_data, preprocessor = build_dataset(with_preprocessor)
+  input_data, _, preprocessor, _ = build_dataset(with_preprocessor)
   estimator = clone(estimator)
   estimator.set_params(preprocessor=preprocessor)
   set_random_state(estimator)
@@ -33,7 +33,7 @@ def test_raise_not_fitted_error_if_not_fitted(estimator, build_dataset,
                                               with_preprocessor):
   """Test that a NotFittedError is raised if someone tries to predict and
   the metric learner has not been fitted."""
-  input_data, preprocessor = build_dataset(with_preprocessor)
+  input_data, _, preprocessor, _ = build_dataset(with_preprocessor)
   estimator = clone(estimator)
   estimator.set_params(preprocessor=preprocessor)
   set_random_state(estimator)
@@ -46,8 +46,7 @@ def test_raise_not_fitted_error_if_not_fitted(estimator, build_dataset,
 def test_accuracy_toy_example(estimator, build_dataset):
   """Test that the default scoring for triplets (accuracy) works on some
   toy example"""
-  triplets, X = build_dataset(with_preprocessor=True)
-  triplets = X[triplets]
+  triplets, _, _, X = build_dataset(with_preprocessor=False)
   estimator = clone(estimator)
   set_random_state(estimator)
   estimator.fit(triplets)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -139,7 +139,7 @@ classifiers = [(Covariance(), build_classification),
                (MMC_Supervised(max_iter=5), build_classification),
                (RCA_Supervised(num_chunks=5), build_classification),
                (SDML_Supervised(prior='identity', balance_param=1e-5),
-               build_classification), 
+               build_classification),
                (SCML_Supervised(), build_classification)]
 ids_classifiers = list(map(lambda x: x.__class__.__name__,
                            [learner for (learner, _) in

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -16,7 +16,7 @@ from metric_learn._util import (check_input, make_context, preprocess_tuples,
 from metric_learn import (ITML, LSML, MMC, RCA, SDML, Covariance, LFDA,
                           LMNN, MLKR, NCA, ITML_Supervised, LSML_Supervised,
                           MMC_Supervised, RCA_Supervised, SDML_Supervised,
-                          SCML_global, SCML_global_Supervised, Constraints)
+                          SCML, SCML_Supervised, Constraints)
 from metric_learn.base_metric import (ArrayIndexer, MahalanobisMixin,
                                       _PairsClassifierMixin,
                                       _TripletsClassifierMixin,
@@ -117,7 +117,7 @@ ids_quadruplets_learners = list(map(lambda x: x.__class__.__name__,
                                 [learner for (learner, _) in
                                  quadruplets_learners]))
 
-triplets_learners = [(SCML_global(), build_triplets)]
+triplets_learners = [(SCML(), build_triplets)]
 ids_triplets_learners = list(map(lambda x: x.__class__.__name__,
                              [learner for (learner, _) in
                               triplets_learners]))
@@ -139,7 +139,7 @@ classifiers = [(Covariance(), build_classification),
                (MMC_Supervised(max_iter=5), build_classification),
                (RCA_Supervised(num_chunks=5), build_classification),
                (SDML_Supervised(prior='identity', balance_param=1e-5),
-               build_classification), (SCML_global_Supervised(),
+               build_classification), (SCML_Supervised(),
                                        build_classification)]
 ids_classifiers = list(map(lambda x: x.__class__.__name__,
                            [learner for (learner, _) in

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -139,8 +139,8 @@ classifiers = [(Covariance(), build_classification),
                (MMC_Supervised(max_iter=5), build_classification),
                (RCA_Supervised(num_chunks=5), build_classification),
                (SDML_Supervised(prior='identity', balance_param=1e-5),
-               build_classification), (SCML_Supervised(),
-                                       build_classification)]
+               build_classification), 
+               (SCML_Supervised(), build_classification)]
 ids_classifiers = list(map(lambda x: x.__class__.__name__,
                            [learner for (learner, _) in
                             classifiers]))
@@ -162,6 +162,9 @@ ids_supervised_learners = ids_classifiers + ids_regressors
 
 metric_learners = tuples_learners + supervised_learners
 ids_metric_learners = ids_tuples_learners + ids_supervised_learners
+
+metric_learners_pipeline = pairs_learners + supervised_learners
+ids_metric_learners_pipeline = ids_pairs_learners + ids_supervised_learners
 
 
 def remove_y(estimator, X, y):


### PR DESCRIPTION
Sparse Compositional Metric Learning (SCML) allows scalable learning of global, multi-task and multiple local Mahalanobis metrics for multi-class data under a unified framework based on sparse combinations of rank-one basis metrics. For this initial merge, only the global setting will be implemented.

The algorithm learns on triplets, so it is necessary to add the base class for the addition of this kind of algorithm. For the sake of clarity, this will be added in a separate concurrent PR.

This implementation follows closely the [matlab implementation](https://github.com/bellet/SCML) of Y. Shi, A. Bellet and F. Sha. Sparse Compositional Metric Learning. AAAI Conference on Artificial Intelligence (AAAI), 2014. [SCML paper](http://researchers.lille.inria.fr/abellet/papers/aaai14.pdf)

**Theory - Global setting**

The Mahalanobis Matrix is constructed as a sum of rank-1 PSD matrices:
<img src="https://user-images.githubusercontent.com/12706143/74540574-51607a80-4f40-11ea-8602-55c524649a21.png" width="350" >
The basis are intended to be locally discriminative. In the original paper and in this implementation they are constructed with LDA of several local regions. There are other options to construct this basis that will be added later.

The constrains are a set of triplets `C` that are inforced through the minimization problem:
<img src="https://user-images.githubusercontent.com/12706143/74543289-6be92280-4f45-11ea-9875-58134c48d300.png" width="550" >

**Advantages** 

- No need to project to SPD cone as M is constructed as a nonegative sum of SPD matrices.
- Only `n_basis` parameters must be learned and stored, without taking into account the basis.
- Uses stochastic composite optimization and in consequence, big datasets can be handled by this algorithm. An efficient implementation of regularized dual averaging is used for the optimization procedure.
- Faster to Train.
- Good Performance on standard datasets (see [paper](http://researchers.lille.inria.fr/abellet/papers/aaai14.pdf) for detailed information) especially on multi-task and local settings. A Benchmark against the other algorithms of the package will be added to this PR later. 
- First algorithm to learn on triplets to be implemented in this package.

**Tests on Vehicles dataset**
The results for the vehicles dataset found in the [matlab implementation github](https://github.com/bellet/SCML) are used to validate the consistency and the correctness of the current implementation.
On each of the tests, the algorithm was run 100 times, the mean and std of the resulted accuracy in test and train, as well as the time, are shown below each test link.
For the batch versions, the numbers of iterations are reduced to have the same amount of gradient computations for each method.

[Test Vanilla](https://gist.github.com/grudloff/29fcb5d529706893c6c33dcd1e4c2aee)
```
Time. Mean:  5.7989197754859925 std:  0.05547399180223441
Train - Accuracy. Mean:  79.3214990138067 std:  0.7612083562308343
Test - Accuracy. Mean:  77.71176470588235 std:  2.056124280977084
```
[Test Batch](https://gist.github.com/grudloff/67208cbc86b9bbc484ba5ac7c64dc07f)
```
Time. Mean:  6.090397052764892 std:  0.048224950065408285
Train - Accuracy. Mean:  81.41222879684418 std:  0.9372967012148159
Test - Accuracy. Mean:  78.0 std:  1.6946894459868151
```
[Test Adagrad](https://gist.github.com/grudloff/73862709ae0a43020cc0a8a02beed9f5)
```
Time. Mean:  6.090397052764892 std:  0.048224950065408285
Train - Accuracy. Mean:  81.41222879684418 std:  0.9372967012148159
Test - Accuracy. Mean:  78.0 std:  1.6946894459868151
```
[Test Batch+Adagrad](https://gist.github.com/grudloff/dc43bf78c7daeecaca8ab4cfc5184ba4)
```
Time. Mean:  1.7653330016136168 std:  0.015989019692575546
Train - Accuracy. Mean:  81.31558185404339 std:  0.9613659886786882
Test - Accuracy. Mean:  78.03529411764706 std:  1.641208095836975
```
We can see that the result are almost the same and even with little variance improvements over the test accuracy. Also the use of mini-batches yields almost a 4-fold improvement on the time used. 

Furthermore, the adagrad version has a faster convergence than the "vanilla" version as it can be observed of the results obtained with 1/20 the number of iterations, as observed on the achieved train acuracy. But this comes with an apparent tradeoff as the test accuracy of the vanilla version is a little bit better, this suggest that maybe it is a good idea to allow both options.
[Test Vanilla - 1/20 iterations](https://gist.github.com/grudloff/ec4bddf365a72e4489c1ac9a6845cf7e)
```
Time. Mean:  1.2541892004013062 std:  0.02197305793469499
Train - Accuracy. Mean:  79.0 std:  0.8888682213828464
Test - Accuracy. Mean:  77.37647058823529 std:  1.5683284028668087
```
[Test Adagrad - 1/20 iterations](https://gist.github.com/grudloff/c5c2fb559c245ad860fa3de9ff0c1941)
```
Time. Mean:  1.3263736057281494 std:  0.020214300581072035
Train - Accuracy. Mean:  80.65483234714003 std:  1.1301895624652614
Test - Accuracy. Mean:  77.0764705882353 std:  2.0688077237684213
```

TODO: 
- [x] Code Comentaries and docstrings
- [x] Documentation
- [x] Basic Tests
- [ ] Specific Tests
- [ ] Benchmark