### PR TITLE
[MRG] Learning on Triplets

### DIFF
--- a/doc/metric_learn.rst
+++ b/doc/metric_learn.rst
@@ -14,6 +14,7 @@ Base Classes
     metric_learn.Constraints
     metric_learn.base_metric.BaseMetricLearner
     metric_learn.base_metric._PairsClassifierMixin
+    metric_learn.base_metric._TripletsClassifierMixin
     metric_learn.base_metric._QuadrupletsClassifierMixin
 
 Supervised Learning Algorithms

--- a/doc/weakly_supervised.rst
+++ b/doc/weakly_supervised.rst
@@ -592,6 +592,119 @@ points, while constrains the sum of distances between dissimilar points:
         -with-side-information.pdf>`_. NIPS 2002
   .. [2] Adapted from Matlab code http://www.cs.cmu.edu/%7Eepxing/papers/Old_papers/code_Metric_online.tar.gz
 
+.. _learning_on_triplets:
+
+Learning on Triplets
+====================
+
+Some metric learning algorithms learn on triplets of samples. In this case,
+one should provide the algorithm with `n_samples` triplets of points. The
+semantic of each triplet is that the first two points should be closer
+together than the first and the last.
+
+Fitting
+-------
+Here is an example for fitting on triplets (see :ref:`fit_ws` for more
+details on the input data format and how to fit, in the general case of
+learning on tuples).
+
+>>> from metric_learn import SCML
+>>> triplets = np.array([[[1.2, 3.2], [2.3, 5.5], [2.1, 0.6]],
+>>>                      [[4.5, 2.3], [2.1, 2.3], [7.3, 3.4]]])
+>>> scml = SCML(random_state=42)
+>>> scml.fit(triplets)
+SCML(beta=1e-5, B=None, max_iter=100000, verbose=False,
+    preprocessor=None, random_state=None)
+
+Or alternatively (using a preprocessor):
+
+>>> X = np.array([[[1.2, 3.2], 
+>>>                [2.3, 5.5],
+>>>                [2.1, 0.6],
+>>>                [4.5, 2.3],
+>>>                [2.1, 2.3],
+>>>                [7.3, 3.4]])
+>>> triplets_indices = np.array([[0, 1, 2], [3, 4, 5]])
+>>> scml = SCML(preprocessor=X, random_state=42)
+>>> scml.fit(triplets_indices)
+SCML(beta=1e-5, B=None, max_iter=100000, verbose=False,
+   preprocessor=array([[1.2, 3.2],
+       [2.3, 5.5],
+       [2.4, 6.7],
+       [2.1, 0.6],
+       [4.5, 2.3],
+       [2.1, 2.3],
+       [0.6, 1.2],
+       [7.3, 3.4]]),
+    random_state=None)
+
+
+Here, we want to learn a metric that, for each of the two
+`triplets`, will put the two first points closer together than the first and the last.
+
+.. _triplets_predicting:
+
+Prediction
+----------
+
+When a triplets learner is fitted, it is also able to predict, for an
+upcoming triplet, whether the two first points are more similar than the
+first and the last (+1), or not (-1).
+
+>>> triplets_test = np.array(
+... [[[5.6, 5.3], [2.2, 2.1], [1.2, 3.4]],
+...  [[6.0, 4.2], [4.3, 1.2], [0.1, 7.8]]])
+>>> scml.predict(triplets_test)
+array([-1.,  1.])
+
+.. _triplets_scoring:
+
+Scoring
+-------
+
+Triplet metric learners can also
+return a `decision_function` for a set of pairs. This is basically the "score"
+which sign will be taken to find the prediction for the pair, which
+corresponds to the difference between the distance between the first two points,
+and the distance between the first and last points of the triplet (higher
+score means the first and last points are more likely to be more dissimilar than
+the two first points (i.e. more likely to have a +1 prediction since it's
+the right ordering)).
+
+>>> scml.decision_function(triplets_test)
+array([-1.75700306,  4.98982131])
+
+In the above example, for the first triplet in `triplets_test`, the
+two first points are predicted less similar than the first and last points (they
+are further away in the transformed space).
+
+Unlike for pairs learners, triplets learners don't allow to give a `y`
+when fitting, which does not allow to use scikit-learn scoring functions
+like:
+
+>>> from sklearn.model_selection import cross_val_score
+>>> cross_val_score(scml, triplets, scoring='f1_score')  # this won't work
+
+(This is actually intentional)
+
+However, triplets learners do have a default scoring function, which will
+basically return the accuracy score on a given test set, i.e. the proportion
+of triplets have the right predicted ordering.
+
+>>> scml.score(triplets_test)
+0.5
+
+.. note::
+   See :ref:`fit_ws` for more details on metric learners functions that are
+   not specific to learning on pairs, like `transform`, `score_pairs`,
+   `get_metric` and `get_mahalanobis_matrix`.
+
+
+
+
+Algorithms
+----------
+
 
 .. _learning_on_quadruplets:
 

--- a/doc/weakly_supervised.rst
+++ b/doc/weakly_supervised.rst
@@ -599,8 +599,8 @@ Learning on Triplets
 
 Some metric learning algorithms learn on triplets of samples. In this case,
 one should provide the algorithm with `n_samples` triplets of points. The
-semantic of each triplet is that the first two points should be closer
-together than the first and the last.
+semantic of each triplet is that the first point should be closer to the
+second point than to the third one.
 
 Fitting
 -------
@@ -640,7 +640,8 @@ SCML(beta=1e-5, B=None, max_iter=100000, verbose=False,
 
 
 Here, we want to learn a metric that, for each of the two
-`triplets`, will put the two first points closer together than the first and the last.
+`triplets`, will make the first point closer to the
+second point than to the third one.
 
 .. _triplets_predicting:
 
@@ -648,8 +649,8 @@ Prediction
 ----------
 
 When a triplets learner is fitted, it is also able to predict, for an
-upcoming triplet, whether the two first points are more similar than the
-first and the last (+1), or not (-1).
+upcoming triplet, whether the first point is closer to the second point 
+than to the third one. (+1), or not (-1).
 
 >>> triplets_test = np.array(
 ... [[[5.6, 5.3], [2.2, 2.1], [1.2, 3.4]],
@@ -662,34 +663,28 @@ array([-1.,  1.])
 Scoring
 -------
 
-Triplet metric learners can also
-return a `decision_function` for a set of pairs. This is basically the "score"
-which sign will be taken to find the prediction for the pair, which
-corresponds to the difference between the distance between the first two points,
-and the distance between the first and last points of the triplet (higher
-score means the first and last points are more likely to be more dissimilar than
-the two first points (i.e. more likely to have a +1 prediction since it's
-the right ordering)).
+Triplet metric learners can also return a `decision_function` for a set of triplets,
+which correspond to the distance between the first two points minus the distance
+between the first and last points of the triplet (the higher the value, the more
+similar the first point to the second point compared to the last one). This "score"
+can be interpreted as a measure of likeliness of having a +1 prediction for this 
+triplet.
 
 >>> scml.decision_function(triplets_test)
 array([-1.75700306,  4.98982131])
 
-In the above example, for the first triplet in `triplets_test`, the
-two first points are predicted less similar than the first and last points (they
-are further away in the transformed space).
+In the above example, for the first triplet in `triplets_test`, the first 
+point is predicted less similar to the second point than to the last point
+(they are further away in the transformed space).
 
-Unlike for pairs learners, triplets learners don't allow to give a `y`
-when fitting, which does not allow to use scikit-learn scoring functions
-like:
-
->>> from sklearn.model_selection import cross_val_score
->>> cross_val_score(scml, triplets, scoring='f1_score')  # this won't work
-
-(This is actually intentional)
+Unlike pairs learners, triplets learners do not allow to give a `y` when fitting: we
+assume that the ordering of points within triplets is such that the training triplets
+are all positive. Therefore, it is not possible to use scikit-learn scoring functions
+(such as 'f1_score') for triplets learners.
 
 However, triplets learners do have a default scoring function, which will
 basically return the accuracy score on a given test set, i.e. the proportion
-of triplets have the right predicted ordering.
+of triplets that have the right predicted ordering.
 
 >>> scml.score(triplets_test)
 0.5
@@ -777,16 +772,14 @@ array([-1.,  1.])
 .. _quadruplets_scoring:
 
 Scoring
--------
+-------W
 
-Quadruplet metric learners can also
-return a `decision_function` for a set of pairs. This is basically the "score"
-which sign will be taken to find the prediction for the pair, which
-corresponds to the difference between the distance between the two last points,
-and the distance between the two last points of the quadruplet (higher
-score means the two last points are more likely to be more dissimilar than
-the two first points (i.e. more likely to have a +1 prediction since it's
-the right ordering)).
+Quadruplet metric learners can also return a `decision_function` for a set of
+quadruplets, which correspond to the distance between the first pair of points minus 
+the distance between the second pair of points of the triplet (the higher the value,
+the more similar the first pair is than the last pair). 
+This "score" can be interpreted as a measure of likeliness of having a +1 prediction 
+for this quadruplet.
 
 >>> lsml.decision_function(quadruplets_test)
 array([-1.75700306,  4.98982131])
@@ -795,17 +788,10 @@ In the above example, for the first quadruplet in `quadruplets_test`, the
 two first points are predicted less similar than the two last points (they
 are further away in the transformed space).
 
-Unlike for pairs learners, quadruplets learners don't allow to give a `y`
-when fitting, which does not allow to use scikit-learn scoring functions
-like:
-
->>> from sklearn.model_selection import cross_val_score
->>> cross_val_score(lsml, quadruplets, scoring='f1_score')  # this won't work
-
-(This is actually intentional, for more details
-about that, see
-`this comment <https://github.com/scikit-learn-contrib/metric-learn/pull/168#pullrequestreview-203730742>`_
-on github.)
+Like triplet learners, quadruplets learners do not allow to give a `y` when fitting: we
+assume that the ordering of points within triplets is such that the training triplets
+are all positive. Therefore, it is not possible to use scikit-learn scoring functions
+(such as 'f1_score') for triplets learners.
 
 However, quadruplets learners do have a default scoring function, which will
 basically return the accuracy score on a given test set, i.e. the proportion

--- a/doc/weakly_supervised.rst
+++ b/doc/weakly_supervised.rst
@@ -594,7 +594,7 @@ points, while constrains the sum of distances between dissimilar points:
 
 .. _learning_on_triplets:
 
-Learning on Triplets
+Learning on triplets
 ====================
 
 Some metric learning algorithms learn on triplets of samples. In this case,
@@ -650,7 +650,7 @@ Prediction
 
 When a triplets learner is fitted, it is also able to predict, for an
 upcoming triplet, whether the first point is closer to the second point 
-than to the third one. (+1), or not (-1).
+than to the third one (+1), or not (-1).
 
 >>> triplets_test = np.array(
 ... [[[5.6, 5.3], [2.2, 2.1], [1.2, 3.4]],
@@ -664,7 +664,7 @@ Scoring
 -------
 
 Triplet metric learners can also return a `decision_function` for a set of triplets,
-which correspond to the distance between the first two points minus the distance
+which corresponds to the distance between the first two points minus the distance
 between the first and last points of the triplet (the higher the value, the more
 similar the first point to the second point compared to the last one). This "score"
 can be interpreted as a measure of likeliness of having a +1 prediction for this 
@@ -707,7 +707,7 @@ Learning on quadruplets
 =======================
 
 Some metric learning algorithms learn on quadruplets of samples. In this case,
-one should provide the algorithm with `n_samples` quadruplets of points. Th
+one should provide the algorithm with `n_samples` quadruplets of points. The
 semantic of each quadruplet is that the first two points should be closer
 together than the last two points.
 
@@ -772,10 +772,10 @@ array([-1.,  1.])
 .. _quadruplets_scoring:
 
 Scoring
--------W
+-------
 
 Quadruplet metric learners can also return a `decision_function` for a set of
-quadruplets, which correspond to the distance between the first pair of points minus 
+quadruplets, which corresponds to the distance between the first pair of points minus 
 the distance between the second pair of points of the triplet (the higher the value,
 the more similar the first pair is than the last pair). 
 This "score" can be interpreted as a measure of likeliness of having a +1 prediction 

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -598,8 +598,8 @@ class _TripletsClassifierMixin(BaseMetricLearner):
   def predict(self, triplets):
     """Predicts the ordering between sample distances in input triplets.
 
-    For each triplets, returns 1 if the first two elements are closer than the
-    first and last and -1 if not.
+    For each triplets, returns 1 if the first element is closer to the second than to the
+    last and -1 if not.
 
     Parameters
     ----------

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -619,11 +619,11 @@ class _TripletsClassifierMixin(BaseMetricLearner):
     """Predicts differences between sample distances in input triplets.
 
     For each triplet (X_a, X_b, X_c) in the samples, computes the difference
-    between the learned metric of the second pair (X_a, X_c) minus the learned
-    metric of the first pair (X_a, X_b). The higher it is, the more probable it
-    is that the pairs in the triplets are presented in the right order, i.e.
-    that the label of the triplet is 1. The lower it is, the more probable it
-    is that the label of the triplet is -1.
+    between the learned distance of the second pair (X_a, X_c) minus the
+    learned distance of the first pair (X_a, X_b). The higher it is, the more
+    probable it is that the pairs in the triplets are presented in the right
+    order, i.e. that the label of the triplet is 1. The lower it is, the more
+    probable it is that the label of the triplet is -1.
 
     Parameters
     ----------

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -613,13 +613,6 @@ class _TripletsClassifierMixin(BaseMetricLearner):
     prediction : `numpy.ndarray` of floats, shape=(n_constraints,)
       Predictions of the ordering of pairs, for each triplet.
     """
-
-    # Aren't the following lines redundant as they are called on
-    # decision_function (as in quadruplets predict) ???
-    # check_is_fitted(self, 'preprocessor_')
-    # triplets = check_input(triplets, type_of_inputs='tuples',
-    #                       preprocessor=self.preprocessor_,
-    #                       estimator=self, tuple_size=self._tuple_size)
     return np.sign(self.decision_function(triplets))
 
   def decision_function(self, triplets):
@@ -705,10 +698,6 @@ class _QuadrupletsClassifierMixin(BaseMetricLearner):
     prediction : `numpy.ndarray` of floats, shape=(n_constraints,)
       Predictions of the ordering of pairs, for each quadruplet.
     """
-    check_is_fitted(self, 'preprocessor_')
-    quadruplets = check_input(quadruplets, type_of_inputs='tuples',
-                              preprocessor=self.preprocessor_,
-                              estimator=self, tuple_size=self._tuple_size)
     return np.sign(self.decision_function(quadruplets))
 
   def decision_function(self, quadruplets):

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -598,8 +598,8 @@ class _TripletsClassifierMixin(BaseMetricLearner):
   def predict(self, triplets):
     """Predicts the ordering between sample distances in input triplets.
 
-    For each triplets, returns 1 if the first element is closer to the second than to the
-    last and -1 if not.
+    For each triplets, returns 1 if the first element is closer to the second
+    than to the last and -1 if not.
 
     Parameters
     ----------

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -604,7 +604,7 @@ class _TripletsClassifierMixin(BaseMetricLearner):
     Parameters
     ----------
     triplets : array-like, shape=(n_triplets, 3, n_features) or (n_triplets, 3)
-      3D Array of triplets to predict, with each row corresponding to three
+      3D array of triplets to predict, with each row corresponding to three
       points, or 2D array of indices of triplets if the metric learner
       uses a preprocessor.
 
@@ -618,18 +618,18 @@ class _TripletsClassifierMixin(BaseMetricLearner):
   def decision_function(self, triplets):
     """Predicts differences between sample distances in input triplets.
 
-    For each triplets in the samples, computes the difference between the
-    learned metric of the second pair minus the learned metric of the first
-    pair. The higher it is, the more probable it is that the pairs in the
-    triplets are presented in the right order, i.e. that the label of the
-    triplet is 1. The lower it is, the more probable it is that the label of
-    the triplet is -1.
+    For each triplet (X_a, X_b, X_c) in the samples, computes the difference
+    between the learned metric of the second pair (X_a, X_c) minus the learned
+    metric of the first pair (X_a, X_b). The higher it is, the more probable it
+    is that the pairs in the triplets are presented in the right order, i.e.
+    that the label of the triplet is 1. The lower it is, the more probable it
+    is that the label of the triplet is -1.
 
     Parameters
     ----------
-    triplet : array-like, shape=(n_triplets, 4, n_features) or \
-                  (n_triplets, 4)
-      3D Array of triplets to predict, with each row corresponding to four
+    triplet : array-like, shape=(n_triplets, 3, n_features) or \
+                  (n_triplets, 3)
+      3D array of triplets to predict, with each row corresponding to three
       points, or 2D array of indices of triplets if the metric learner
       uses a preprocessor.
 
@@ -646,17 +646,17 @@ class _TripletsClassifierMixin(BaseMetricLearner):
             self.score_pairs(triplets[:, :2]))
 
   def score(self, triplets):
-    """Computes score on input triplets
+    """Computes score on input triplets.
 
-    Returns the accuracy score of the following classification task: a record
-    is correctly classified if the predicted similarity between the first two
-    samples is higher than that of the first and last element.
+    Returns the accuracy score of the following classification task: a triplet
+    (X_a, X_b, X_c) is correctly classified if the predicted similarity between
+    the first pair (X_a, X_b) is higher than that of the second pair (X_a, X_c)
 
     Parameters
     ----------
-    triplets : array-like, shape=(n_triplets, 4, n_features) or \
-                  (n_triplets, 4)
-      3D Array of triplets to score, with each row corresponding to four
+    triplets : array-like, shape=(n_triplets, 3, n_features) or \
+                  (n_triplets, 3)
+      3D array of triplets to score, with each row corresponding to three
       points, or 2D array of indices of triplets if the metric learner
       uses a preprocessor.
 

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -36,9 +36,31 @@ class Constraints(object):
     return a, b, c, d
 
   def generate_knntriplets(self, X, k_genuine, k_impostor):
+    """
+    Generates triplets for every point to `k_genuine` neighbors of the same
+    class and `k_impostor` neighbors of other classes.
+
+    For every point (X_a) the triplets (X_a, X_b, X_c) are constructed from all
+    the combinations of taking `k_genuine` neighbors (X_b) of the same class
+    and `k_impostor` neighbors (X_c) of other classes.
+
+    Parameters
+    ----------
+      X : (n x d) matrix
+        Input data, where each row corresponds to a single instance.
+      k_genuine : int
+        Number of neighbors of the same class to be taken into account.
+      k_impostor : int
+        Number of neighbors of different classes to be taken into account.
+
+    Returns
+    -------
+    triplets : array-like, shape=(n_constraints, 3)
+      2D array of triplets of indicators.
+    """
 
     labels = np.unique(self.partial_labels)
-    L = len(labels)
+    n_labels = len(labels)
     len_input = np.size(self.partial_labels, 0)
     triplets = np.empty((len_input*k_genuine*k_impostor, 3), dtype=np.intp)
 
@@ -46,7 +68,7 @@ class Constraints(object):
     finish = 0
     neigh = NearestNeighbors()
 
-    for i in range(L):
+    for i in range(n_labels):
 
         # generate mask for current label
         gen_mask = self.partial_labels == labels[i]
@@ -67,7 +89,7 @@ class Constraints(object):
                             X=X[gen_mask],
                             return_distance=False))
 
-        # lenght = len_label*k_genuine*k_impostor
+        # length = len_label*k_genuine*k_impostor
         finish += np.sum(gen_mask)*k_genuine*k_impostor
 
         triplets[start:finish, :] = self._comb(gen_indx, gen_neigh, imp_neigh,
@@ -79,6 +101,7 @@ class Constraints(object):
     return triplets
 
   def _comb(self, A, B, C, sizeB, sizeC):
+    # generate_knntripelts helper function
     # generate an array will all combinations of choosing
     # an element from A, B and C
     return np.vstack((repmat(A, sizeB*sizeC, 1).ravel(order='F'),

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -63,7 +63,11 @@ class Constraints(object):
     triplets : array-like, shape=(n_constraints, 3)
       2D array of triplets of indicators.
     """
-    known_labels = self.partial_labels[self.partial_labels >= 0]
+    # Ignore unlabeled samples
+    known_labels_mask = self.partial_labels >= 0
+    known_labels = self.partial_labels[known_labels_mask]
+    X = X[known_labels_mask]
+
     labels, labels_count = np.unique(known_labels, return_counts=True)
     len_input = known_labels.shape[0]
 

--- a/test/test_constraints.py
+++ b/test/test_constraints.py
@@ -94,8 +94,8 @@ def test_generate_knntriplets_under_edge(k_genuine, k_impostor, T_test):
   """Checks under the edge cases of knn triplet construction with enough
      neighbors"""
 
-  X = np.array([[0, 0], [2, 2], [4, 4], [8, 8], [16, 16], [32, 32]])
-  y = np.array([1, 1, 1, 2, 2, 2])
+  X = np.array([[0, 0], [2, 2], [4, 4], [8, 8], [16, 16], [32, 32], [64, 64]])
+  y = np.array([1, 1, 1, 2, 2, 2, -1])
 
   T = Constraints(y).generate_knntriplets(X, k_genuine, k_impostor)
 
@@ -115,8 +115,8 @@ def test_generate_knntriplets(k_genuine, k_impostor):
             [4, 3, 0], [4, 3, 1], [4, 3, 2], [4, 5, 0], [4, 5, 1], [4, 5, 2],
             [5, 3, 0], [5, 3, 1], [5, 3, 2], [5, 4, 0], [5, 4, 1], [5, 4, 2]]
 
-  X = np.array([[0, 0], [2, 2], [4, 4], [8, 8], [16, 16], [32, 32]])
-  y = np.array([1, 1, 1, 2, 2, 2])
+  X = np.array([[0, 0], [2, 2], [4, 4], [8, 8], [16, 16], [32, 32], [64, 64]])
+  y = np.array([1, 1, 1, 2, 2, 2, -1])
 
   T = Constraints(y).generate_knntriplets(X, k_genuine, k_impostor)
 

--- a/test/test_constraints.py
+++ b/test/test_constraints.py
@@ -72,32 +72,8 @@ def test_unknown_labels_not_in_chunks(num_chunks, chunk_size):
   assert np.all(chunks[labels < 0] < 0)
 
 
-def test_generate_knntriplets():
-  """Toy example validation of knn triplets construction"""
-  k = 1
-  X = np.array([[0, 0], [2, 2], [4, 4], [8, 8], [16, 16], [32, 32], [64, 64],
-                [128, 128], [256, 256]])
-  y = np.array([1, 1, 1, 2, 2, 2, 3, 3, 3])
-
-  T_test = np.array([[0, 1, 3], [1, 0, 3], [2, 1, 3], [3, 4, 2], [4, 3, 2],
-                     [5, 4, 2], [6, 7, 5], [7, 6, 5], [8, 7, 5]])
-  T = Constraints(y).generate_knntriplets(X, k, k)
-
-  assert np.array_equal(sorted(T.tolist()), sorted(T_test.tolist()))
-
-
 @pytest.mark.parametrize("k_genuine, k_impostor, T_test",
-                         [(2, 3,
-                          [[0, 1, 3], [0, 1, 4], [0, 1, 5], [0, 2, 3],
-                           [0, 2, 4], [0, 2, 5], [1, 0, 3], [1, 0, 4],
-                           [1, 0, 5], [1, 2, 3], [1, 2, 4], [1, 2, 5],
-                           [2, 0, 3], [2, 0, 4], [2, 0, 5], [2, 1, 3],
-                           [2, 1, 4], [2, 1, 5], [3, 4, 0], [3, 4, 1],
-                           [3, 4, 2], [3, 5, 0], [3, 5, 1], [3, 5, 2],
-                           [4, 3, 0], [4, 3, 1], [4, 3, 2], [4, 5, 0],
-                           [4, 5, 1], [4, 5, 2], [5, 3, 0], [5, 3, 1],
-                           [5, 3, 2], [5, 4, 0], [5, 4, 1], [5, 4, 2]]),
-                          (2, 2,
+                         [(2, 2,
                           [[0, 1, 3], [0, 1, 4], [0, 2, 3], [0, 2, 4],
                            [1, 0, 3], [1, 0, 4], [1, 2, 3], [1, 2, 4],
                            [2, 0, 3], [2, 0, 4], [2, 1, 3], [2, 1, 4],
@@ -114,8 +90,30 @@ def test_generate_knntriplets():
                           [[0, 1, 3], [0, 1, 4], [1, 0, 3], [1, 0, 4],
                            [2, 1, 3], [2, 1, 4], [3, 4, 1], [3, 4, 2],
                            [4, 3, 1], [4, 3, 2], [5, 4, 1], [5, 4, 2]])])
-def test_generate_knntriplets_k(k_genuine, k_impostor, T_test):
-  """Checks edge cases of knn triplet construction"""
+def test_generate_knntriplets_under_edge(k_genuine, k_impostor, T_test):
+  """Checks under the edge cases of knn triplet construction with enough
+     neighbors"""
+
+  X = np.array([[0, 0], [2, 2], [4, 4], [8, 8], [16, 16], [32, 32]])
+  y = np.array([1, 1, 1, 2, 2, 2])
+
+  T = Constraints(y).generate_knntriplets(X, k_genuine, k_impostor)
+
+  assert np.array_equal(sorted(T.tolist()), T_test)
+
+
+@pytest.mark.parametrize("k_genuine, k_impostor,",
+                         [(2, 3), (3, 3), (2, 4), (3, 4)])
+def test_generate_knntriplets(k_genuine, k_impostor):
+  """Checks edge and over the edge cases of knn triplet construction with not
+     enough neighbors"""
+
+  T_test = [[0, 1, 3], [0, 1, 4], [0, 1, 5], [0, 2, 3], [0, 2, 4], [0, 2, 5],
+            [1, 0, 3], [1, 0, 4], [1, 0, 5], [1, 2, 3], [1, 2, 4], [1, 2, 5],
+            [2, 0, 3], [2, 0, 4], [2, 0, 5], [2, 1, 3], [2, 1, 4], [2, 1, 5],
+            [3, 4, 0], [3, 4, 1], [3, 4, 2], [3, 5, 0], [3, 5, 1], [3, 5, 2],
+            [4, 3, 0], [4, 3, 1], [4, 3, 2], [4, 5, 0], [4, 5, 1], [4, 5, 2],
+            [5, 3, 0], [5, 3, 1], [5, 3, 2], [5, 4, 0], [5, 4, 1], [5, 4, 2]]
 
   X = np.array([[0, 0], [2, 2], [4, 4], [8, 8], [16, 16], [32, 32]])
   y = np.array([1, 1, 1, 2, 2, 2])

--- a/test/test_constraints.py
+++ b/test/test_constraints.py
@@ -74,25 +74,11 @@ def test_unknown_labels_not_in_chunks(num_chunks, chunk_size):
 
 def test_generate_knntriplets():
   k = 1
-  X = np.array([[0, 0],
-               [1, 1],
-               [2, 2],
-               [3, 3],
-               [4, 4],
-               [5, 5],
-               [6, 6],
-               [7, 7],
+  X = np.array([[0, 0], [1, 1], [2, 2], [3, 3], [4, 4], [5, 5], [6, 6], [7, 7],
                [8, 8]])
   y = np.array([1, 1, 1, 2, 2, 2, 3, 3, 3])
-  T_test = np.array([[0, 1, 3],
-                    [1, 0, 3],
-                    [2, 1, 3],
-                    [3, 4, 2],
-                    [4, 3, 2],
-                    [5, 4, 6],
-                    [6, 7, 5],
-                    [7, 6, 5],
-                    [8, 7, 5]])
+  T_test = np.array([[0, 1, 3], [1, 0, 3], [2, 1, 3], [3, 4, 2], [4, 3, 2],
+                     [5, 4, 6], [6, 7, 5], [7, 6, 5], [8, 7, 5]])
   T = Constraints(y).generate_knntriplets(X, k, k)
 
   assert np.array_equal(T, T_test)
@@ -110,11 +96,11 @@ def test_generate_knntriplets_k_genuine():
   warn_msgs = []
   for idx in idx_smallest_label[0]:
     k_genuine = labels_count[idx]
-    warn_msgs.append("The class {} has {} elements but a minimum of {},"
-                     " which corresponds to k_genuine+1, is expected. "
-                     "A lower number of k_genuine will be used for this"
-                     "class.\n"
-                     .format(label[idx], k_genuine, k_genuine+1))
+    warn_msgs.append("The class {} has {} elements, which is not sufficient "
+                     "to generate {} genuine neighbors as specified by "
+                     "k_genuine. Will generate {} genuine neighbors instead."
+                     "\n"
+                     .format(label[idx], k_genuine, k_genuine+1, k_genuine-1))
 
   with pytest.warns(UserWarning) as raised_warning:
     Constraints(y).generate_knntriplets(X, k_genuine, 1)
@@ -135,11 +121,12 @@ def test_generate_knntriplets_k_impostor():
 
   warn_msgs = []
   for idx in idx_smallest_label[0]:
-    warn_msgs.append("The class {} has {} elements of other classes but a "
-                     "minimum of {}, which corresponds to k_impostor, is"
-                     " expected. A lower number of k_impostor will be used"
-                     " for this class.\n"
-                     .format(label[idx], k_impostor-1, k_impostor))
+    warn_msgs.append("The class {} has {} elements of other classes, which is"
+                     " not sufficient to generate {} impostor neighbors as "
+                     "specified by k_impostor. Will generate {} impostor "
+                     "neighbors instead.\n"
+                     .format(label[idx], k_impostor-1, k_impostor,
+                             k_impostor-1))
 
   with pytest.warns(UserWarning) as raised_warning:
     Constraints(y).generate_knntriplets(X, 1, k_impostor)

--- a/test/test_constraints.py
+++ b/test/test_constraints.py
@@ -94,7 +94,7 @@ def test_generate_knntriplets_under_edge(k_genuine, k_impostor, T_test):
   """Checks under the edge cases of knn triplet construction with enough
      neighbors"""
 
-  X = np.array([[0, 0], [2, 2], [4, 4], [8, 8], [16, 16], [32, 32], [64, 64]])
+  X = np.array([[0, 0], [2, 2], [4, 4], [8, 8], [16, 16], [32, 32], [33, 33]])
   y = np.array([1, 1, 1, 2, 2, 2, -1])
 
   T = Constraints(y).generate_knntriplets(X, k_genuine, k_impostor)
@@ -115,7 +115,7 @@ def test_generate_knntriplets(k_genuine, k_impostor):
             [4, 3, 0], [4, 3, 1], [4, 3, 2], [4, 5, 0], [4, 5, 1], [4, 5, 2],
             [5, 3, 0], [5, 3, 1], [5, 3, 2], [5, 4, 0], [5, 4, 1], [5, 4, 2]]
 
-  X = np.array([[0, 0], [2, 2], [4, 4], [8, 8], [16, 16], [32, 32], [64, 64]])
+  X = np.array([[0, 0], [2, 2], [4, 4], [8, 8], [16, 16], [32, 32], [33, 33]])
   y = np.array([1, 1, 1, 2, 2, 2, -1])
 
   T = Constraints(y).generate_knntriplets(X, k_genuine, k_impostor)

--- a/test/test_constraints.py
+++ b/test/test_constraints.py
@@ -3,6 +3,7 @@ import numpy as np
 from sklearn.utils import shuffle
 from metric_learn.constraints import Constraints
 from sklearn.datasets import make_blobs
+from sklearn.neighbors import NearestNeighbors
 
 SEED = 42
 
@@ -73,15 +74,99 @@ def test_unknown_labels_not_in_chunks(num_chunks, chunk_size):
 
 
 def test_generate_knntriplets():
+  """Toy example validation of knn triplets construction"""
   k = 1
-  X = np.array([[0, 0], [1, 1], [2, 2], [3, 3], [4, 4], [5, 5], [6, 6], [7, 7],
-               [8, 8]])
+  X = np.array([[0, 0], [2, 2], [4, 4], [8, 8], [16, 16], [32, 32], [64, 64],
+                [128, 128], [256, 256]])
   y = np.array([1, 1, 1, 2, 2, 2, 3, 3, 3])
+
   T_test = np.array([[0, 1, 3], [1, 0, 3], [2, 1, 3], [3, 4, 2], [4, 3, 2],
-                     [5, 4, 6], [6, 7, 5], [7, 6, 5], [8, 7, 5]])
+                     [5, 4, 2], [6, 7, 5], [7, 6, 5], [8, 7, 5]])
   T = Constraints(y).generate_knntriplets(X, k, k)
 
-  assert np.array_equal(T, T_test)
+  assert len(list(set(map(tuple, T)) - set(map(tuple, T_test)))) == 0
+
+
+@pytest.mark.parametrize("delta_genuine, delta_impostor", [(1, 1), (1, 2),
+                                                           (2, 1), (2, 2)])
+def test_generate_knntriplets_k(delta_genuine, delta_impostor):
+  """Checks edge cases of knn triplet construction"""
+  X, y = shuffle(*make_blobs(random_state=SEED),
+                 random_state=SEED)
+
+  label, labels_count = np.unique(y, return_counts=True)
+  labels_count_min = np.min(labels_count)
+  k_genuine = labels_count_min - delta_genuine
+
+  length = len(y)
+  labels_count_max = np.max(labels_count)
+  k_impostor = length - labels_count_max + 1 - delta_impostor
+
+  T = Constraints(y).generate_knntriplets(X, k_genuine, k_impostor)
+  T_test = naive_generate_knntriplets(X, y, k_genuine, k_impostor)
+
+  assert len(list(set(map(tuple, T)) - set(map(tuple, T_test)))) == 0
+
+
+def naive_generate_knntriplets(X, y, k_genuine, k_impostor):
+  """
+  Generates triplets from labeled data. Naive implementation
+  intended for testing.
+
+  Parameters
+  ----------
+    X : (n x d) matrix
+      Input data, where each row corresponds to a single instance.
+    k_genuine : int
+      Number of neighbors of the same class to be taken into account.
+    k_impostor : int
+      Number of neighbors of different classes to be taken into account.
+
+  Returns
+  -------
+  triplets : array-like, shape=(n_constraints, 3)
+    2D array of triplets of indicators.
+  """
+
+  labels, labels_count = np.unique(y, return_counts=True)
+  n_labels = len(labels)
+  len_input = np.size(y, 0)
+
+  triplets = np.empty((len_input*k_genuine*k_impostor, 3),
+                      dtype=np.intp)
+
+  j = 0
+  neigh = NearestNeighbors()
+
+  for i in range(n_labels):
+
+      # generate mask for current label
+      gen_mask = y == labels[i]
+      gen_indx = np.where(gen_mask)
+
+      # get k_genuine genuine neighbours
+      neigh.fit(X=X[gen_indx])
+      gen_neigh = np.take(gen_indx, neigh.kneighbors(
+                          n_neighbors=k_genuine,
+                          return_distance=False))
+
+      # generate mask for impostors of current label
+      imp_indx = np.where(np.invert(gen_mask))
+
+      # get k_impostor impostor neighbours
+      neigh.fit(X=X[imp_indx])
+      imp_neigh = np.take(imp_indx, neigh.kneighbors(
+                          n_neighbors=k_impostor,
+                          X=X[gen_mask],
+                          return_distance=False))
+
+      for a, k in zip(gen_indx[0], range(len(gen_indx[0]))):
+        for b in gen_neigh[k, :]:
+          for c in imp_neigh[k, :]:
+            triplets[j, :] = np.array([a, b, c])
+            j += 1
+
+  return triplets
 
 
 def test_generate_knntriplets_k_genuine():
@@ -92,10 +177,10 @@ def test_generate_knntriplets_k_genuine():
   label, labels_count = np.unique(y, return_counts=True)
   labels_count_min = np.min(labels_count)
   idx_smallest_label = np.where(labels_count == labels_count_min)
+  k_genuine = labels_count_min
 
   warn_msgs = []
   for idx in idx_smallest_label[0]:
-    k_genuine = labels_count[idx]
     warn_msgs.append("The class {} has {} elements, which is not sufficient "
                      "to generate {} genuine neighbors as specified by "
                      "k_genuine. Will generate {} genuine neighbors instead."
@@ -116,11 +201,11 @@ def test_generate_knntriplets_k_impostor():
   length = len(y)
   label, labels_count = np.unique(y, return_counts=True)
   labels_count_max = np.max(labels_count)
-  idx_smallest_label = np.where(labels_count == labels_count_max)
+  idx_biggest_label = np.where(labels_count == labels_count_max)
   k_impostor = length - labels_count_max + 1
 
   warn_msgs = []
-  for idx in idx_smallest_label[0]:
+  for idx in idx_biggest_label[0]:
     warn_msgs.append("The class {} has {} elements of other classes, which is"
                      " not sufficient to generate {} impostor neighbors as "
                      "specified by k_impostor. Will generate {} impostor "

--- a/test/test_constraints.py
+++ b/test/test_constraints.py
@@ -130,11 +130,11 @@ def test_generate_knntriplets_k_genuine():
 
   label, labels_count = np.unique(y, return_counts=True)
   labels_count_min = np.min(labels_count)
-  idx_smallest_label = np.where(labels_count == labels_count_min)
+  idx_smallest_label, = np.where(labels_count == labels_count_min)
   k_genuine = labels_count_min
 
   warn_msgs = []
-  for idx in idx_smallest_label[0]:
+  for idx in idx_smallest_label:
     warn_msgs.append("The class {} has {} elements, which is not sufficient "
                      "to generate {} genuine neighbors as specified by "
                      "k_genuine. Will generate {} genuine neighbors instead."
@@ -155,11 +155,11 @@ def test_generate_knntriplets_k_impostor():
   length = len(y)
   label, labels_count = np.unique(y, return_counts=True)
   labels_count_max = np.max(labels_count)
-  idx_biggest_label = np.where(labels_count == labels_count_max)
+  idx_biggest_label, = np.where(labels_count == labels_count_max)
   k_impostor = length - labels_count_max + 1
 
   warn_msgs = []
-  for idx in idx_biggest_label[0]:
+  for idx in idx_biggest_label:
     warn_msgs.append("The class {} has {} elements of other classes, which is"
                      " not sufficient to generate {} impostor neighbors as "
                      "specified by k_impostor. Will generate {} impostor "

--- a/test/test_triplets_classifiers.py
+++ b/test/test_triplets_classifiers.py
@@ -57,7 +57,7 @@ def test_accuracy_toy_example(estimator, build_dataset):
   set_random_state(estimator)
   estimator.fit(triplets)
   # We take the two first points and we build 4 regularly spaced points on the
-  # line they define, so that it's easy to build quadruplets of different
+  # line they define, so that it's easy to build triplets of different
   # similarities.
   X_test = X[0] + np.arange(4)[:, np.newaxis] * (X[0] - X[1]) / 4
 

--- a/test/test_triplets_classifiers.py
+++ b/test/test_triplets_classifiers.py
@@ -1,0 +1,71 @@
+import pytest
+from sklearn.exceptions import NotFittedError
+from sklearn.model_selection import train_test_split
+
+from test.test_utils import triplets_learners, ids_triplets_learners
+from sklearn.utils.testing import set_random_state
+from sklearn import clone
+import numpy as np
+
+
+@pytest.mark.parametrize('with_preprocessor', [True, False])
+@pytest.mark.parametrize('estimator, build_dataset', triplets_learners,
+                         ids=ids_triplets_learners)
+def test_predict_only_one_or_minus_one(estimator, build_dataset,
+                                       with_preprocessor):
+  """Test that all predicted values are either +1 or -1"""
+  input_data, preprocessor = build_dataset(with_preprocessor)
+  estimator = clone(estimator)
+  estimator.set_params(preprocessor=preprocessor)
+  set_random_state(estimator)
+  triplets_train, triplets_test = train_test_split(input_data)
+  estimator.fit(triplets_train)
+  predictions = estimator.predict(triplets_test)
+  for i in range(len(input_data)):
+    prediction = estimator.predict(input_data[None, i])
+    if(prediction == 0):
+      print(input_data[i])
+      print(preprocessor[input_data[i]])
+      print(estimator.decision_function(input_data[None, i]))
+  not_valid = [e for e in predictions if e not in [-1, 1]]
+  assert len(not_valid) == 0
+
+
+@pytest.mark.parametrize('with_preprocessor', [True, False])
+@pytest.mark.parametrize('estimator, build_dataset', triplets_learners,
+                         ids=ids_triplets_learners)
+def test_raise_not_fitted_error_if_not_fitted(estimator, build_dataset,
+                                              with_preprocessor):
+  """Test that a NotFittedError is raised if someone tries to predict and
+  the metric learner has not been fitted."""
+  input_data, preprocessor = build_dataset(with_preprocessor)
+  estimator = clone(estimator)
+  estimator.set_params(preprocessor=preprocessor)
+  set_random_state(estimator)
+  with pytest.raises(NotFittedError):
+    estimator.predict(input_data)
+
+
+@pytest.mark.parametrize('estimator, build_dataset', triplets_learners,
+                         ids=ids_triplets_learners)
+def test_accuracy_toy_example(estimator, build_dataset):
+  """Test that the default scoring for triplets (accuracy) works on some
+  toy example"""
+  triplets, X = build_dataset(with_preprocessor=True)
+  triplets = X[triplets]
+  estimator = clone(estimator)
+  set_random_state(estimator)
+  estimator.fit(triplets)
+  # We take the two first points and we build 4 regularly spaced points on the
+  # line they define, so that it's easy to build quadruplets of different
+  # similarities.
+  X_test = X[0] + np.arange(4)[:, np.newaxis] * (X[0] - X[1]) / 4
+
+  triplets_test = np.array(
+      [[X_test[0], X_test[2], X_test[1]],
+       [X_test[1], X_test[3], X_test[0]],
+       [X_test[1], X_test[2], X_test[3]],
+       [X_test[3], X_test[0], X_test[2]]])
+  # we force the transformation to be identity so that we control what it does
+  estimator.components_ = np.eye(X.shape[1])
+  assert estimator.score(triplets_test) == 0.25

--- a/test/test_triplets_classifiers.py
+++ b/test/test_triplets_classifiers.py
@@ -21,12 +21,7 @@ def test_predict_only_one_or_minus_one(estimator, build_dataset,
   triplets_train, triplets_test = train_test_split(input_data)
   estimator.fit(triplets_train)
   predictions = estimator.predict(triplets_test)
-  for i in range(len(input_data)):
-    prediction = estimator.predict(input_data[None, i])
-    if(prediction == 0):
-      print(input_data[i])
-      print(preprocessor[input_data[i]])
-      print(estimator.decision_function(input_data[None, i]))
+
   not_valid = [e for e in predictions if e not in [-1, 1]]
   assert len(not_valid) == 0
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -89,7 +89,7 @@ def build_triplets(with_preprocessor=False):
   input_data, labels = load_iris(return_X_y=True)
   X, y = shuffle(input_data, labels, random_state=SEED)
   constraints = Constraints(y)
-  triplets = constraints.generate_knntriplets(X, 3, 10)
+  triplets = constraints.generate_knntriplets(X, 3, 4)
   if with_preprocessor:
     # if preprocessor, we build a 2D array of triplets of indices
     return triplets, X

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -89,7 +89,7 @@ def build_triplets(with_preprocessor=False):
   input_data, labels = load_iris(return_X_y=True)
   X, y = shuffle(input_data, labels, random_state=SEED)
   constraints = Constraints(y)
-  triplets = constraints.generate_knntriplets(X, 3, 4)
+  triplets = constraints.generate_knntriplets(X, k_genuine=3, k_impostor=4)
   if with_preprocessor:
     # if preprocessor, we build a 2D array of triplets of indices
     return triplets, X


### PR DESCRIPTION
[WIP] Learning on Triplets

This PR is intended to allow the implementation of algorithms that learn on triplets by adding the base class for this kind of learner. The semantic of triplets is similar to quadruplets but the positive and negative pairs are constructed with respect to the first element of the triplet, for this the added code follows closely the one for quadruplets. 

The main reason for the creation of this is the implementation of SCML (PR  #278) an algorithm that learns on triplets. This will also enable the implementation of future algorithms that learn on triplets.

TODO:

- [x] add `_TripletsClassifierMixin` to `base_metric.py`
- [x] Tests
- [x] Documentation