### PR TITLE
Travis CI: correct pytest version for python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     python: "3.4"
     before_install:
       - sudo apt-get install liblapack-dev
-      - pip install --upgrade pip pytest
+      - pip install --upgrade pip "pytest<5"
       - pip install wheel cython numpy scipy codecov pytest-cov scikit-learn
     script:
       - pytest test --cov;


### PR DESCRIPTION
This fixes the CI failure due to pytest 5.x dropping support for Python 3.4

Very soon (next release?) we should ourselves drop support for Python 2.7 and 3.4, as discussed in #166  