### PR TITLE
Update paper ref after JMLR acceptance

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,17 +49,20 @@ If you use metric-learn in a scientific publication, we would appreciate
 citations to the following paper:
 
 `metric-learn: Metric Learning Algorithms in Python
-<https://arxiv.org/abs/1908.04710>`_, de Vazelhes
-*et al.*, arXiv:1908.04710, 2019.
+<http://www.jmlr.org/papers/volume21/19-678/19-678.pdf>`_, de Vazelhes
+*et al.*, Journal of Machine Learning Research, 21(138):1-6, 2020.
 
 Bibtex entry::
 
-  @techreport{metric-learn,
-    title = {metric-learn: {M}etric {L}earning {A}lgorithms in {P}ython},
+  @article{metric-learn,
+    title   = {metric-learn: {M}etric {L}earning {A}lgorithms in {P}ython},
     author = {{de Vazelhes}, William and {Carey}, CJ and {Tang}, Yuan and
               {Vauquier}, Nathalie and {Bellet}, Aur{\'e}lien},
-    institution = {arXiv:1908.04710},
-    year = {2019}
+    journal = {Journal of Machine Learning Research},
+    year = {2020},
+    volume = {21},
+    number = {138},
+    pages = {1--6}
   }
 
 .. _sphinx documentation: http://contrib.scikit-learn.org/metric-learn/

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ citations to the following paper:
 Bibtex entry::
 
   @article{metric-learn,
-    title   = {metric-learn: {M}etric {L}earning {A}lgorithms in {P}ython},
+    title = {metric-learn: {M}etric {L}earning {A}lgorithms in {P}ython},
     author = {{de Vazelhes}, William and {Carey}, CJ and {Tang}, Yuan and
               {Vauquier}, Nathalie and {Bellet}, Aur{\'e}lien},
     journal = {Journal of Machine Learning Research},

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,17 +15,20 @@ If you use metric-learn in a scientific publication, we would appreciate
 citations to the following paper:
 
 `metric-learn: Metric Learning Algorithms in Python
-<https://arxiv.org/abs/1908.04710>`_, de Vazelhes
-*et al.*, arXiv:1908.04710, 2019.
+<http://www.jmlr.org/papers/volume21/19-678/19-678.pdf>`_, de Vazelhes
+*et al.*, Journal of Machine Learning Research, 21(138):1-6, 2020.
 
 Bibtex entry::
 
-  @techreport{metric-learn,
-    title = {metric-learn: {M}etric {L}earning {A}lgorithms in {P}ython},
+  @article{metric-learn,
+    title   = {metric-learn: {M}etric {L}earning {A}lgorithms in {P}ython},
     author = {{de Vazelhes}, William and {Carey}, CJ and {Tang}, Yuan and
               {Vauquier}, Nathalie and {Bellet}, Aur{\'e}lien},
-    institution = {arXiv:1908.04710},
-    year = {2019}
+    journal = {Journal of Machine Learning Research},
+    year = {2020},
+    volume = {21},
+    number = {138},
+    pages = {1--6}
   }
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,7 +21,7 @@ citations to the following paper:
 Bibtex entry::
 
   @article{metric-learn,
-    title   = {metric-learn: {M}etric {L}earning {A}lgorithms in {P}ython},
+    title = {metric-learn: {M}etric {L}earning {A}lgorithms in {P}ython},
     author = {{de Vazelhes}, William and {Carey}, CJ and {Tang}, Yuan and
               {Vauquier}, Nathalie and {Bellet}, Aur{\'e}lien},
     journal = {Journal of Machine Learning Research},


### PR DESCRIPTION
This updates the reference to the metric-learn paper in the README and the doc, following acceptance to JMLR