### PR TITLE
Feat fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ htmlcov/
 .pytest_cache/
 doc/auto_examples/*
 doc/generated/*
+venv/

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -929,7 +929,7 @@ class TestNCA(MetricTestCase):
       X = X[[ind_0[0], ind_1[0], ind_2[0]]]
       y = y[[ind_0[0], ind_1[0], ind_2[0]]]
 
-      A = make_spd_matrix(X.shape[1], X.shape[1])
+      A = make_spd_matrix(n_dim=X.shape[1], random_state=X.shape[1])
       nca = NCA(init=A, max_iter=30, n_components=X.shape[1])
       nca.fit(X, y)
       assert_array_equal(nca.components_, A)
@@ -940,7 +940,7 @@ class TestNCA(MetricTestCase):
       X = self.iris_points[self.iris_labels == 0]
       y = self.iris_labels[self.iris_labels == 0]
 
-      A = make_spd_matrix(X.shape[1], X.shape[1])
+      A = make_spd_matrix(n_dim=X.shape[1], random_state=X.shape[1])
       nca = NCA(init=A, max_iter=30, n_components=X.shape[1])
       nca.fit(X, y)
       assert_array_equal(nca.components_, A)

--- a/test/test_mahalanobis_mixin.py
+++ b/test/test_mahalanobis_mixin.py
@@ -503,12 +503,12 @@ def test_init_mahalanobis(estimator, build_dataset):
       model.fit(input_data, labels)
 
       # Initialize with a random spd matrix
-      init = make_spd_matrix(X.shape[1], random_state=rng)
+      init = make_spd_matrix(n_dim=X.shape[1], random_state=rng)
       model.set_params(**{param: init})
       model.fit(input_data, labels)
 
       # init.shape[1] must match X.shape[1]
-      init = make_spd_matrix(X.shape[1] + 1, X.shape[1] + 1)
+      init = make_spd_matrix(n_dim=X.shape[1] + 1, random_state=rng)
       model.set_params(**{param: init})
       msg = ('The input dimensionality {} of the given '
              'mahalanobis matrix `{}` must match the '


### PR DESCRIPTION
5 Tests were not passing because of **make_spd_matrix()** function. The usage was incorrect.

According to [documentation](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.make_spd_matrix.html?highlight=make_spd_matrix#sklearn.datasets.make_spd_matrix), you just need to provide **n_dim** and **random_state**, in order to generate the random spd matrix.

With this little change, those tests pass