### PR TITLE
Addressing LFDA sign indeterminacy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ htmlcov/
 .pytest_cache/
 doc/auto_examples/*
 doc/generated/*
+venv/

--- a/doc/supervised.rst
+++ b/doc/supervised.rst
@@ -292,6 +292,11 @@ same class are not imposed to be close.
     lfda = LFDA(k=2, dim=2)
     lfda.fit(X, Y)
 
+.. note::
+    LDFA suffers from a problem called “sign indeterminacy”, which means the sign of the ``components`` and the output from transform depend on a random state. This is directly related to the calculation of eigenvectors in the algorithm. The same input ran in different times might lead to different transforms, but both valid.
+    
+    To work around this, fit instances of this class to data once, then keep the instance around to do transformations.
+
 .. topic:: References:
 
     .. [1] Sugiyama. `Dimensionality Reduction of Multimodal Labeled Data by Local


### PR DESCRIPTION
Resolves #211 

I've looked for this issue and was able to replicate the random behavior when calculating the eigenvectors. Effectively it may happen that some eigenvectors might be signed-flipped, if you execute the code at different times.

None of the scipy functions we use to calculate the eigenvectors in LFDA supports something like a 'random_state': [scipy.linalg.eigh](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.eigh.html), [scipy.linalg.eig ](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.eig.html)and [scipy.sparse.linalg.eigsh](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.eigsh.html)

There are two alternatives:

1. We implement some kind of "convention" to force/determine the behavior. For instance, "Every first value of an eigenvector must be positive, otherwise flip the sign of the entire vector". (Flipping sign of an eigenvector, doesn't affect the eigenvector property)
2. Add a Note in documentation just like sklearn does for [SVD](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.TruncatedSVD.html)

Number 1 decreases performance a bit, and number 2 seems more reasonable. Consider the message I made a draft.