### PR TITLE
YML file: CI Migration to Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
-        run:  sudo apt-get install liblapack-dev
+        run:  |
+              sudo apt-get install liblapack-dev
               pip install --upgrade pip pytest
               pip install wheel cython numpy scipy codecov pytest-cov scikit-learn
               pytest test --cov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,6 @@ jobs:
         env:
           SKGGM_VERSION: a0ed406586c4364ea3297a658f415e13b5cbdaf8
         run:  |
-          sudo apt-get install liblapack-dev
-          pip install --upgrade pip pytest
-          pip install wheel cython numpy scipy codecov pytest-cov scikit-learn
           pip install git+https://github.com/skggm/skggm.git@${SKGGM_VERSION}
           pytest test --cov
           bash <(curl -s https://codecov.io/bash)
@@ -47,11 +44,8 @@ jobs:
         env:
           SKGGM_VERSION: a0ed406586c4364ea3297a658f415e13b5cbdaf8
         run:  |
-          sudo apt-get install liblapack-dev
-          pip install --upgrade pip pytest
-          pip install wheel cython numpy scipy codecov pytest-cov
+          pip uninstall scikit-learn
           pip install scikit-learn==0.20.3
-          pip install git+https://github.com/skggm/skggm.git@${SKGGM_VERSION}
           pytest test --cov
           bash <(curl -s https://codecov.io/bash)
       - name: Syntax checking with flake8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         python-version: ['2.7', '3.6', '3.7', '3.8', 'pypy-2.7', 'pypy-3.6']
         exclude:
           - os: macos-latest
@@ -32,9 +32,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
-        run:  |
-              sudo apt-get install liblapack-dev
-              pip install --upgrade pip pytest
-              pip install wheel cython numpy scipy codecov pytest-cov scikit-learn
-              pytest test --cov
+      - run:  sudo apt-get install liblapack-dev
+      - run:  pip install --upgrade pip pytest
+      - run:  pip install wheel cython numpy scipy codecov pytest-cov scikit-learn
+      - run:  pytest test --cov
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,11 +20,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['2.7', '3.6', '3.7', '3.8', 'pypy-2.7', 'pypy-3.6']
-        exclude:
-          - os: macos-latest
-            python-version: '3.8'
-          - os: windows-latest
-            python-version: '3.6'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -32,8 +27,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
-      - run:  sudo apt-get install liblapack-dev
-      - run:  pip install --upgrade pip pytest
-      - run:  pip install wheel cython numpy scipy codecov pytest-cov scikit-learn
-      - run:  pytest test --cov
+        run:  |
+          sudo apt-get install liblapack-dev
+          pip install --upgrade pip pytest
+          pip install wheel cython numpy scipy codecov pytest-cov scikit-learn
+          pytest test --cov
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,39 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['2.7', '3.6', '3.7', '3.8', 'pypy-2.7', 'pypy-3.6']
+        exclude:
+          - os: macos-latest
+            python-version: '3.8'
+          - os: windows-latest
+            python-version: '3.6'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Display Python version
+        run:  sudo apt-get install liblapack-dev
+              pip install --upgrade pip pytest
+              pip install wheel cython numpy scipy codecov pytest-cov scikit-learn
+              pytest test --cov
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,29 @@ on:
   workflow_dispatch:
 
 jobs:
+  compatibility:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.6', '3.7', '3.8', '3.9']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run Tests with skggm + scikit-learn 0.20.3
+        env:
+          SKGGM_VERSION: a0ed406586c4364ea3297a658f415e13b5cbdaf8
+        run:  |
+          sudo apt-get install liblapack-dev
+          pip install --upgrade pip pytest
+          pip install wheel cython numpy scipy codecov pytest-cov
+          pip install scikit-learn==0.20.3
+          pip install git+https://github.com/skggm/skggm.git@${SKGGM_VERSION}
+          pytest test --cov
+          bash <(curl -s https://codecov.io/bash)
   build:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['2.7', '3.6', '3.7', '3.8', 'pypy-2.7', 'pypy-3.6']
+        python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy-3.6']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,14 +63,6 @@ jobs:
           pip install git+https://github.com/skggm/skggm.git@${SKGGM_VERSION}
           pytest test --cov
           bash <(curl -s https://codecov.io/bash)
-      - name: Run Tests with skggm + scikit-learn 0.20.3
-        env:
-          SKGGM_VERSION: a0ed406586c4364ea3297a658f415e13b5cbdaf8
-        run:  |
-          pip uninstall scikit-learn
-          pip install scikit-learn==0.20.3
-          pytest test --cov
-          bash <(curl -s https://codecov.io/bash)
       - name: Syntax checking with flake8
         run: |
           pip install flake8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy-3.6']
+        python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy-3.6', 'pypy-3.7']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -32,4 +32,5 @@ jobs:
           pip install --upgrade pip pytest
           pip install wheel cython numpy scipy codecov pytest-cov scikit-learn
           pytest test --cov
-
+      - name: Codecov
+        uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
           pip install --upgrade pip pytest
           pip install wheel cython numpy scipy codecov pytest-cov scikit-learn
           pytest test --cov
+          bash <(curl -s https://codecov.io/bash)
       - name: Run Tests with skggm
         env:
           SKGGM_VERSION: a0ed406586c4364ea3297a658f415e13b5cbdaf8
@@ -41,6 +42,7 @@ jobs:
           pip install wheel cython numpy scipy codecov pytest-cov scikit-learn
           pip install git+https://github.com/skggm/skggm.git@${SKGGM_VERSION}
           pytest test --cov
+          bash <(curl -s https://codecov.io/bash)
       - name: Run Tests with skggm + scikit-learn 0.20.3
         env:
           SKGGM_VERSION: a0ed406586c4364ea3297a658f415e13b5cbdaf8
@@ -51,9 +53,8 @@ jobs:
           pip install scikit-learn==0.20.3
           pip install git+https://github.com/skggm/skggm.git@${SKGGM_VERSION}
           pytest test --cov
+          bash <(curl -s https://codecov.io/bash)
       - name: Syntax checking with flake8
         run: |
           pip install flake8
           flake8 --extend-ignore=E111,E114 --show-source;
-      - name: Codecov
-        uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,18 +19,41 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy-3.6', 'pypy-3.7']
+        python-version: ['3.6', '3.7', '3.8', '3.9']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Display Python version
+      - name: Run Tests without skggm
         run:  |
           sudo apt-get install liblapack-dev
           pip install --upgrade pip pytest
           pip install wheel cython numpy scipy codecov pytest-cov scikit-learn
           pytest test --cov
+      - name: Run Tests with skggm
+        env:
+          SKGGM_VERSION: a0ed406586c4364ea3297a658f415e13b5cbdaf8
+        run:  |
+          sudo apt-get install liblapack-dev
+          pip install --upgrade pip pytest
+          pip install wheel cython numpy scipy codecov pytest-cov scikit-learn
+          pip install git+https://github.com/skggm/skggm.git@${SKGGM_VERSION}
+          pytest test --cov
+      - name: Run Tests with skggm + scikit-learn 0.20.3
+        env:
+          SKGGM_VERSION: a0ed406586c4364ea3297a658f415e13b5cbdaf8
+        run:  |
+          sudo apt-get install liblapack-dev
+          pip install --upgrade pip pytest
+          pip install wheel cython numpy scipy codecov pytest-cov
+          pip install scikit-learn==0.20.3
+          pip install git+https://github.com/skggm/skggm.git@${SKGGM_VERSION}
+          pytest test --cov
+      - name: Syntax checking with flake8
+        run: |
+          pip install flake8
+          flake8 --extend-ignore=E111,E114 --show-source;
       - name: Codecov
         uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,3 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
 # Controls when the workflow will run
@@ -9,11 +7,10 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
+    
 jobs:
+
+  # Checks compatibility with an old version of sklearn (0.20.3)
   compatibility:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -37,6 +34,8 @@ jobs:
           pip install git+https://github.com/skggm/skggm.git@${SKGGM_VERSION}
           pytest test --cov
           bash <(curl -s https://codecov.io/bash)
+          
+  # Run normal testing with the latests versions of all dependencies
   build:
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Resolves #325 

Developed a draft YML file that handles the migration from Travis CI to Github actions.

- Python 3.6, 3.7 and 3.8 are tested with sklearn=0.20.3 + skggm for compatibility. Python 3.9 doesn't work for some reason
- Python 3.6, 3.7, 3.8 and 3.9 are tested with latest versions of dependencies, with and without skggm
- Test reports are uploaded to Codecov, as before
- Flake8 always run in the end
- All tests run on the latest Ubuntu x64

Sorry for making too many commits, I could not find a way to debug this. But only one file is added and its automatically recognized by Guthub Actions.

This proposal is already working on my fork of metric_learning, at master branch.