### PR TITLE
Change min sklearn version to 0.21.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,27 +10,27 @@ on:
     
 jobs:
 
-  # Checks compatibility with an old version of sklearn (0.20.3)
+  # Checks compatibility with an old version of sklearn (0.21.3)
   compatibility:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.6', '3.7']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Run Tests with skggm + scikit-learn 0.20.3
+      - name: Run Tests with skggm + scikit-learn 0.21.3
         env:
           SKGGM_VERSION: a0ed406586c4364ea3297a658f415e13b5cbdaf8
         run:  |
           sudo apt-get install liblapack-dev
           pip install --upgrade pip pytest
           pip install wheel cython numpy scipy codecov pytest-cov
-          pip install scikit-learn==0.20.3
+          pip install scikit-learn==0.21.3
           pip install git+https://github.com/skggm/skggm.git@${SKGGM_VERSION}
           pytest test --cov
           bash <(curl -s https://codecov.io/bash)

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ metric-learn contains efficient Python implementations of several popular superv
 
 -  Python 3.6+ (the last version supporting Python 2 and Python 3.5 was
    `v0.5.0 <https://pypi.org/project/metric-learn/0.5.0/>`_)
--  numpy, scipy, scikit-learn>=0.20.3
+-  numpy>= 1.11.0, scipy>= 0.17.0, scikit-learn>=0.21.3
 
 **Optional dependencies**
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -19,7 +19,7 @@ metric-learn can be installed in either of the following ways:
 
 - Python 3.6+ (the last version supporting Python 2 and Python 3.5 was
   `v0.5.0 <https://pypi.org/project/metric-learn/0.5.0/>`_)
-- numpy, scipy, scikit-learn>=0.20.3
+- numpy>= 1.11.0, scipy>= 0.17.0, scikit-learn>=0.21.3
 
 **Optional dependencies**
 

--- a/setup.py
+++ b/setup.py
@@ -63,9 +63,9 @@ setup(name='metric-learn',
       ],
       packages=['metric_learn'],
       install_requires=[
-          'numpy',
-          'scipy',
-          'scikit-learn>=0.20.3',
+          'numpy>= 1.11.0',
+          'scipy>= 0.17.0',
+          'scikit-learn>=0.21.3',
       ],
       extras_require=dict(
           docs=['sphinx', 'shinx_rtd_theme', 'numpydoc'],


### PR DESCRIPTION
Reviewing the release notes of sklearn ([here](https://scikit-learn.org/stable/install.html#install-by-distribution)), I realized that the version that is being checked in CI is 0.20.3 wich has an official support for Python 2.7 and 3.4 **only**.

This is inconsistent, because metric_learn only supports Python 3.6+.

Then, the minimum version of sklearn allowed should be 0.21.3 wich is the older version officially supporting Python 3.6. Also the older version with documentation ([here](https://scikit-learn.org/0.21/install.html)).

There should also be restrictions to _numpy_ and _scipy_, to at least match the minimum versions required for sklearn 0.21.3.

For the CI, only Python 3.6 and 3.7 should be checked, as only these verions are officially supported by sklearn 0.21.3

Modified: setup.py, readme, docs and CI