### PR TITLE
[Tests][Warnings] Cut all warnings from SCML using a minimal solution

### DIFF
--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -95,7 +95,7 @@ class TestSCML(object):
                                n_informative=60, n_redundant=0, n_repeated=0,
                                random_state=42)
     X = StandardScaler().fit_transform(X)
-    scml = SCML_Supervised(random_state=42)
+    scml = SCML_Supervised(random_state=42, n_basis=399)
     scml.fit(X, y)
     csep = class_separation(scml.transform(X), y)
     assert csep < 0.7
@@ -106,7 +106,7 @@ class TestSCML(object):
                                                          [2, 0], [2, 1]]),
                                                np.array([1, 0, 1, 0])))])
   def test_bad_basis(self, estimator, data):
-    model = estimator(basis='bad_basis')
+    model = estimator(basis='bad_basis', n_basis=33)  # n_basis doesn't matter
     msg = ("`basis` must be one of the options '{}' or an array of shape "
            "(n_basis, n_features)."
            .format("', '".join(model._authorized_basis)))
@@ -238,16 +238,23 @@ class TestSCML(object):
   @pytest.mark.parametrize('n_features', [10, 50, 100])
   @pytest.mark.parametrize('n_classes', [5, 10, 15])
   def test_triplet_diffs(self, n_samples, n_features, n_classes):
+    """
+    Test that the correct value of n_basis is being generated with
+    different triplet constraints.
+    """
     X, y = make_classification(n_samples=n_samples, n_classes=n_classes,
                                n_features=n_features, n_informative=n_features,
                                n_redundant=0, n_repeated=0)
     X = StandardScaler().fit_transform(X)
-
-    model = SCML_Supervised()
+    model = SCML_Supervised(n_basis=None)  # Explicit n_basis=None
     constraints = Constraints(y)
     triplets = constraints.generate_knntriplets(X, model.k_genuine,
                                                 model.k_impostor)
-    basis, n_basis = model._generate_bases_dist_diff(triplets, X)
+
+    msg = "As no value for `n_basis` was selected, "
+    with pytest.warns(UserWarning) as raised_warning:
+      basis, n_basis = model._generate_bases_dist_diff(triplets, X)
+    assert msg in str(raised_warning[0].message)
 
     expected_n_basis = n_features * 80
     assert n_basis == expected_n_basis
@@ -257,13 +264,21 @@ class TestSCML(object):
   @pytest.mark.parametrize('n_features', [10, 50, 100])
   @pytest.mark.parametrize('n_classes', [5, 10, 15])
   def test_lda(self, n_samples, n_features, n_classes):
+    """
+    Test that when n_basis=None, the correct n_basis is generated,
+    for SCML_Supervised and different values of n_samples, n_features
+    and n_classes.
+    """
     X, y = make_classification(n_samples=n_samples, n_classes=n_classes,
                                n_features=n_features, n_informative=n_features,
                                n_redundant=0, n_repeated=0)
     X = StandardScaler().fit_transform(X)
 
-    model = SCML_Supervised()
-    basis, n_basis = model._generate_bases_LDA(X, y)
+    msg = "As no value for `n_basis` was selected, "
+    with pytest.warns(UserWarning) as raised_warning:
+      model = SCML_Supervised(n_basis=None)  # Explicit n_basis=None
+      basis, n_basis = model._generate_bases_LDA(X, y)
+    assert msg in str(raised_warning[0].message)
 
     num_eig = min(n_classes - 1, n_features)
     expected_n_basis = min(20 * n_features, n_samples * 2 * num_eig - 1)
@@ -299,7 +314,7 @@ class TestSCML(object):
     assert msg == raised_error.value.args[0]
 
   def test_large_output_iter(self):
-    scml = SCML(max_iter=1, output_iter=2)
+    scml = SCML(max_iter=1, output_iter=2, n_basis=33)  # n_basis don't matter
     triplets = np.array([[[0, 1], [2, 1], [0, 0]]])
     msg = ("The value of output_iter must be equal or smaller than"
            " max_iter.")

--- a/test/test_mahalanobis_mixin.py
+++ b/test/test_mahalanobis_mixin.py
@@ -291,8 +291,8 @@ def test_components_is_2D(estimator, build_dataset):
   model.fit(*remove_y(estimator, input_data, labels))
   assert model.components_.shape == (X.shape[1], X.shape[1])
 
-  # test that it works for 1 feature
-  trunc_data = input_data[..., :1]
+  # test that it works for 1 feature. Use 2nd dimention, to avoid border cases
+  trunc_data = input_data[..., 1:2]
   # we drop duplicates that might have been formed, i.e. of the form
   # aabc or abcc or aabb for quadruplets, and aa for pairs.
 

--- a/test/test_sklearn_compat.py
+++ b/test/test_sklearn_compat.py
@@ -79,7 +79,10 @@ class TestSklearnCompat(unittest.TestCase):
     check_estimator(Stable_RCA_Supervised())
 
   def test_scml(self):
-    check_estimator(SCML_Supervised())
+    msg = "As no value for `n_basis` was selected, "
+    with pytest.warns(UserWarning) as raised_warning:
+      check_estimator(SCML_Supervised())
+    assert msg in str(raised_warning[0].message)
 
 
 RNG = check_random_state(0)

--- a/test/test_triplets_classifiers.py
+++ b/test/test_triplets_classifiers.py
@@ -1,7 +1,6 @@
 import pytest
 from sklearn.exceptions import NotFittedError
 from sklearn.model_selection import train_test_split
-import metric_learn
 
 from test.test_utils import triplets_learners, ids_triplets_learners
 from metric_learn.sklearn_shims import set_random_state
@@ -21,13 +20,7 @@ def test_predict_only_one_or_minus_one(estimator, build_dataset,
   estimator.set_params(preprocessor=preprocessor)
   set_random_state(estimator)
   triplets_train, triplets_test = train_test_split(input_data)
-  if isinstance(estimator, metric_learn.SCML):
-    msg = "As no value for `n_basis` was selected, "
-    with pytest.warns(UserWarning) as raised_warning:
-      estimator.fit(triplets_train)
-    assert msg in str(raised_warning[0].message)
-  else:
-    estimator.fit(triplets_train)
+  estimator.fit(triplets_train)
   predictions = estimator.predict(triplets_test)
 
   not_valid = [e for e in predictions if e not in [-1, 1]]
@@ -49,13 +42,7 @@ def test_no_zero_prediction(estimator, build_dataset):
   # Dummy fit
   estimator = clone(estimator)
   set_random_state(estimator)
-  if isinstance(estimator, metric_learn.SCML):
-    msg = "As no value for `n_basis` was selected, "
-    with pytest.warns(UserWarning) as raised_warning:
-      estimator.fit(triplets)
-    assert msg in str(raised_warning[0].message)
-  else:
-    estimator.fit(triplets)
+  estimator.fit(triplets)
   # We force the transformation to be identity, to force euclidean distance
   estimator.components_ = np.eye(X.shape[1])
 
@@ -106,13 +93,7 @@ def test_accuracy_toy_example(estimator, build_dataset):
   triplets, _, _, X = build_dataset(with_preprocessor=False)
   estimator = clone(estimator)
   set_random_state(estimator)
-  if isinstance(estimator, metric_learn.SCML):
-    msg = "As no value for `n_basis` was selected, "
-    with pytest.warns(UserWarning) as raised_warning:
-      estimator.fit(triplets)
-    assert msg in str(raised_warning[0].message)
-  else:
-    estimator.fit(triplets)
+  estimator.fit(triplets)
   # We take the two first points and we build 4 regularly spaced points on the
   # line they define, so that it's easy to build triplets of different
   # similarities.

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -117,7 +117,7 @@ ids_quadruplets_learners = list(map(lambda x: x.__class__.__name__,
                                 [learner for (learner, _) in
                                  quadruplets_learners]))
 
-triplets_learners = [(SCML(), build_triplets)]
+triplets_learners = [(SCML(n_basis=320), build_triplets)]
 ids_triplets_learners = list(map(lambda x: x.__class__.__name__,
                              [learner for (learner, _) in
                               triplets_learners]))
@@ -140,7 +140,7 @@ classifiers = [(Covariance(), build_classification),
                (RCA_Supervised(num_chunks=5), build_classification),
                (SDML_Supervised(prior='identity', balance_param=1e-5),
                build_classification),
-               (SCML_Supervised(), build_classification)]
+               (SCML_Supervised(n_basis=80), build_classification)]
 ids_classifiers = list(map(lambda x: x.__class__.__name__,
                            [learner for (learner, _) in
                             classifiers]))


### PR DESCRIPTION
As suggested by @bellet in #339, it's better to cut SCML warnings from the root by specifying the `n_basis` value when its possible.

As all test run the iris dataset for SCML though `build_triplets` at `test_utils.py`, then we just need to scpecify `n_basis` for `SCML` and `SCML_Supervised` in the lists.

Going through the code of `SCML`, if `n_basis` is `None`, then the following default is assigned:

Default for SCML_Supervised: ([lines 579-583](https://github.com/scikit-learn-contrib/metric-learn/blob/aaf8d44b8d31d6ea418f0bd80ef86958e5081b4c/metric_learn/scml.py#L583))
```python
n_basis = min(20*n_features, n_samples*2*min(n_classes-1, n_features) - 1)
```
Default for SCML: ([line 234](https://github.com/scikit-learn-contrib/metric-learn/blob/aaf8d44b8d31d6ea418f0bd80ef86958e5081b4c/metric_learn/scml.py#L234))
```python
n_basis = n_features*80
```
Iris dataset has 150 samples, 3 classes, 4 features. So the value is 80 for `SCML_Supervised` and 320 for `SCML`.

I changed it, but got the following tests failing.

- In `test_components_is_2D` at `test_mahalanobis_mixin.py` there is an error because of a border case. I got this warning from SCML:
```
The number of bases with nonzero weight is less than the number of features of the input, in consequence the learned transformation reduces the dimension to 0
```
And this error from the test:
```
>     assert model.components_.shape == (1, 1)  # the components must be 2D
E     assert (0, 1) == (1, 1)
E       At index 0 diff: 0 != 1
E       Use -v to get the full diff
```
So the test want to test `fit` for just one feature. Right now the feature selected from Iris is the 1st one, but  if we use 2nd dimension instead, we can avoid this border case and make the test pass. The behavior expected is the same.
```python
# trunc_data = input_data[..., :1]  # Old
trunc_data = input_data[..., 1:2]  # New
```

- There is also an error in `test_sklearn_compat.py`, `TestSklearnCompat` class, `test_scml`, `check_estimator` function if `n_basis` is arbitrary, because under the hood it calls `fit()` wich calls `_generate_bases_LDA`, and if `n_basis` is wrong, it may fail. Thus, we need to let `SCML` calc `n_basis` for us as we don't know wich random `X, y` dataset is being used. Thus, we need to use `pytest.warn` to catch the warning.

- Not an error, but an obervation in `test_triplet_diffs` and `test_lda`: These tests needs an explicitly `n_basis=None` to check if it is being set correctly internally, thus, in this case the warning needs to be caught as well.

Besides this observations, **all warnings from SCML were removed. Only 300-ish warnings are shown now across all tests.**

Also, this PR removes the `isinstance()` overkill made in `test_triplets_clasifiers.py` previously.

Best! 🎃