### PR TITLE
[DOC] Fixed small error in Code Snipplet in Docs

### DIFF
--- a/doc/supervised.rst
+++ b/doc/supervised.rst
@@ -164,8 +164,8 @@ indicates :math:`\mathbf{x}_{i}, \mathbf{x}_{j}` belong to different classes,
     X = iris_data['data']
     Y = iris_data['target']
 
-    lmnn = LMNN(n_neighbors=5, learn_rate=1e-6)
-    lmnn.fit(X, Y, verbose=False)
+    lmnn = LMNN(n_neighbors=5, learn_rate=1e-6, verbose=False)
+    lmnn.fit(X, Y)
 
 .. rubric:: References
 


### PR DESCRIPTION
The verbose (and almost all other parameters) need to be passed to the constructor and not the .fit() function. This was not reflected in the example snipplets for LMNN in the docs and let new users (like me) to make errors based on the docs.